### PR TITLE
Update website, revise docs, and bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open `http://localhost:5173`, add your API key(s) in Settings, and start chattin
 | **WebLLM** | Local (WebGPU) | Qwen3-4B, Qwen3-30B | Yes (parsed) |
 | **Chrome AI** | Local (built-in) | Gemini Nano | No (summarization only) |
 
-### Provider Routing (Design B)
+### Provider Routing
 
 SafeClaw uses quality-first routing:
 
@@ -49,10 +49,10 @@ SafeClaw uses quality-first routing:
 ┌──────────────────────────────────────────────────────────┐
 │  Browser Tab (PWA)                                       │
 │                                                          │
-│  ┌──────────┐  ┌──────────┐  ┌────────────────────────┐  │
-│  │ Chat UI  │  │ Settings │  │ Task Manager           │  │
-│  └────┬─────┘  └─────┬────┘  └───────┬────────────────┘  │
-│       └──────────────┼───────────────┘                   │
+│  ┌────────┐ ┌────────┐ ┌───────┐ ┌───────┐ ┌──────────┐  │
+│  │ Chat   │ │Settings│ │ Files │ │ Tasks │ │Use Cases │  │
+│  └───┬────┘ └───┬────┘ └──┬────┘ └──┬────┘ └────┬─────┘  │
+│       └──────┴────────┼────────┴──────┘                   │
 │                      ▼                                   │
 │              Orchestrator (main thread)                  │
 │              ├── Provider Router (quality-first)         │

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -433,7 +433,7 @@
       <div class="provider-card">
         <div class="icon">🟣</div>
         <h3>Anthropic Claude</h3>
-        <p>Claude Opus 4, Sonnet 4, and Haiku — industry-leading reasoning with extended thinking and tool use.</p>
+        <p>Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 — industry-leading reasoning with extended thinking and tool use.</p>
         <span class="tag tag-cloud">Cloud</span>
       </div>
       <div class="provider-card">
@@ -494,6 +494,26 @@
         <h3>Persistent Memory</h3>
         <p>Conversations, files, and tasks persist in IndexedDB and OPFS. Your assistant remembers context across sessions.</p>
       </div>
+      <div class="feature-card">
+        <div class="icon">📨</div>
+        <h3>Telegram Integration</h3>
+        <p>Connect a Telegram bot to chat with your assistant from any device. Pure HTTPS — no WebSockets or special protocols required.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">⏰</div>
+        <h3>Task Scheduling</h3>
+        <p>Schedule recurring tasks with cron expressions. Your assistant runs them automatically in the background while your tab is open.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">📂</div>
+        <h3>File Workspace</h3>
+        <p>Built-in file manager backed by Origin Private File System (OPFS). Read, write, and browse files in per-group workspaces.</p>
+      </div>
+      <div class="feature-card">
+        <div class="icon">💡</div>
+        <h3>Use Case Recommendations</h3>
+        <p>Personalized AI use-case suggestions based on your profile. Discover 20+ curated workflows across automation, research, and development.</p>
+      </div>
     </div>
   </section>
 
@@ -522,7 +542,7 @@
       <p>No magic, no hidden complexity. A transparent pipeline from message to response.</p>
     </div>
     <div class="arch-diagram">
-      <div class="layer arch-l1">React UI — Chat, Settings, Thinking Log</div>
+      <div class="layer arch-l1">React UI — Chat, Settings, Files, Tasks, Use Cases</div>
       <div class="arch-arrow">↕</div>
       <div class="layer arch-l2">Zustand Store — Reactive State Bridge</div>
       <div class="arch-arrow">↕</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safeclaw",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safeclaw",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@mlc-ai/web-llm": "^0.2.81",
         "lucide-react": "^0.575.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safeclaw",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "description": "Browser-native personal AI assistant. Zero infrastructure — the browser is the server.",


### PR DESCRIPTION
- Website: fix model names (Claude Opus 4.6, Sonnet 4.6, Haiku 4.5), add Telegram, Task Scheduling, File Workspace, and Use Case Recommendations feature cards, update architecture diagram to show all five UI pages (Chat, Settings, Files, Tasks, Use Cases)
- README: update architecture diagram with Files/Tasks/Use Cases pages, remove "Design B" label from Provider Routing heading
- package.json: bump version from 0.1.0 to 1.0.0

Closes #11

https://claude.ai/code/session_01W1TNSGRUizrhrqYqive6y2