### PR TITLE
Add PWA install and update notifications

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -6,6 +6,8 @@ import { Outlet, NavLink } from 'react-router';
 import { MessageSquare, FolderOpen, Clock, Settings, Lightbulb } from 'lucide-react';
 import { ThemeToggle } from './ThemeToggle.js';
 import { FileViewerModal } from '../files/FileViewerModal.js';
+import { InstallBanner } from '../pwa/InstallBanner.js';
+import { UpdateToast } from '../pwa/UpdateToast.js';
 import { useFileViewerStore } from '../../stores/file-viewer-store.js';
 
 const navItems = [
@@ -55,6 +57,9 @@ export function Layout() {
         </div>
       </div>
 
+      {/* ---- PWA install banner ---- */}
+      <InstallBanner />
+
       {/* ---- Page content ---- */}
       <main className="flex-1 overflow-hidden pb-16 sm:pb-0">
         <Outlet />
@@ -73,6 +78,9 @@ export function Layout() {
           </NavLink>
         ))}
       </div>
+
+      {/* ---- PWA update toast ---- */}
+      <UpdateToast />
 
       {/* ---- Global file viewer modal ---- */}
       {viewerFile && (

--- a/src/components/pwa/InstallBanner.tsx
+++ b/src/components/pwa/InstallBanner.tsx
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — PWA Install Banner
+// ---------------------------------------------------------------------------
+
+import { Download, Share, X } from 'lucide-react';
+import { usePwaInstall } from '../../hooks/use-pwa-install.js';
+
+export function InstallBanner() {
+  const { canInstall, platform, promptInstall, dismiss } = usePwaInstall();
+
+  if (!canInstall) return null;
+
+  return (
+    <div className="alert alert-info shadow-lg mx-4 mt-2" role="alert">
+      <Download className="w-5 h-5 shrink-0" />
+      <div className="flex-1">
+        <h3 className="font-bold text-sm">Install SafeClaw</h3>
+        {platform === 'ios' ? (
+          <p className="text-xs">
+            Tap the <Share className="w-3 h-3 inline" /> Share button, then select{' '}
+            <strong>Add to Home Screen</strong>.
+          </p>
+        ) : (
+          <p className="text-xs">Install as an app for quick access and offline use.</p>
+        )}
+      </div>
+      <div className="flex gap-1">
+        {platform === 'chromium' && (
+          <button
+            className="btn btn-sm btn-primary"
+            onClick={promptInstall}
+            aria-label="Install"
+          >
+            Install
+          </button>
+        )}
+        <button
+          className="btn btn-sm btn-ghost"
+          onClick={dismiss}
+          aria-label="Dismiss install banner"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pwa/UpdateToast.tsx
+++ b/src/components/pwa/UpdateToast.tsx
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — PWA Update Toast
+// ---------------------------------------------------------------------------
+
+import { RefreshCw, Wifi, X } from 'lucide-react';
+import { usePwaUpdate } from '../../hooks/use-pwa-update.js';
+
+export function UpdateToast() {
+  const { needRefresh, offlineReady, updateServiceWorker, dismissUpdate } = usePwaUpdate();
+
+  if (!needRefresh && !offlineReady) return null;
+
+  return (
+    <div className="toast toast-end toast-bottom z-50">
+      <div className="alert alert-info shadow-lg">
+        {needRefresh ? (
+          <>
+            <RefreshCw className="w-5 h-5 shrink-0" />
+            <div className="flex-1">
+              <span className="text-sm font-semibold">New version available</span>
+            </div>
+            <div className="flex gap-1">
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={updateServiceWorker}
+                aria-label="Reload to update"
+              >
+                Reload
+              </button>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={dismissUpdate}
+                aria-label="Dismiss update notification"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <Wifi className="w-5 h-5 shrink-0" />
+            <div className="flex-1">
+              <span className="text-sm">Ready to work offline</span>
+            </div>
+            <button
+              className="btn btn-sm btn-ghost"
+              onClick={dismissUpdate}
+              aria-label="Dismiss offline notification"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — PWA Install Prompt Hook
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+type Platform = 'chromium' | 'ios' | null;
+
+interface PwaInstallState {
+  canInstall: boolean;
+  platform: Platform;
+  promptInstall: () => Promise<string | undefined>;
+  dismiss: () => void;
+}
+
+function detectIos(): boolean {
+  const isIosUA = /iPhone|iPad|iPod/.test(navigator.userAgent);
+  const isStandalone = (navigator as Navigator & { standalone?: boolean }).standalone;
+  // On iOS Safari, navigator.standalone exists but is false when not installed.
+  // When it's true, the app is already running as PWA.
+  return isIosUA && isStandalone !== true;
+}
+
+export function usePwaInstall(): PwaInstallState {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [platform, setPlatform] = useState<Platform>(() => {
+    if (detectIos()) return 'ios';
+    return null;
+  });
+  const [canInstall, setCanInstall] = useState<boolean>(() => detectIos());
+
+  useEffect(() => {
+    function handleBeforeInstall(e: Event) {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setPlatform('chromium');
+      setCanInstall(true);
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstall);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstall);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async (): Promise<string | undefined> => {
+    if (!deferredPrompt) return undefined;
+    const result = await deferredPrompt.prompt();
+    setDeferredPrompt(null);
+    setCanInstall(false);
+    return result.outcome;
+  }, [deferredPrompt]);
+
+  const dismiss = useCallback(() => {
+    setCanInstall(false);
+  }, []);
+
+  return { canInstall, platform, promptInstall, dismiss };
+}

--- a/src/hooks/use-pwa-update.ts
+++ b/src/hooks/use-pwa-update.ts
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — PWA Update Notification Hook
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { registerSW } from 'virtual:pwa-register';
+
+interface PwaUpdateState {
+  needRefresh: boolean;
+  offlineReady: boolean;
+  updateServiceWorker: () => Promise<void>;
+  dismissUpdate: () => void;
+}
+
+export function usePwaUpdate(): PwaUpdateState {
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const [offlineReady, setOfflineReady] = useState(false);
+  const updateSWRef = useRef<((reloadPage?: boolean) => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    const updateSW = registerSW({
+      onNeedRefresh() {
+        setNeedRefresh(true);
+      },
+      onOfflineReady() {
+        setOfflineReady(true);
+      },
+    });
+    updateSWRef.current = updateSW;
+  }, []);
+
+  const updateServiceWorker = useCallback(async () => {
+    if (updateSWRef.current) {
+      await updateSWRef.current(true);
+    }
+  }, []);
+
+  const dismissUpdate = useCallback(() => {
+    setNeedRefresh(false);
+    setOfflineReady(false);
+  }, []);
+
+  return { needRefresh, offlineReady, updateServiceWorker, dismissUpdate };
+}

--- a/tests/components/pwa/InstallBanner.test.tsx
+++ b/tests/components/pwa/InstallBanner.test.tsx
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// InstallBanner component tests
+// ---------------------------------------------------------------------------
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock the usePwaInstall hook
+const mockPromptInstall = vi.fn();
+const mockDismiss = vi.fn();
+let mockCanInstall = false;
+let mockPlatform: 'chromium' | 'ios' | null = null;
+
+vi.mock('../../../src/hooks/use-pwa-install.js', () => ({
+  usePwaInstall: () => ({
+    canInstall: mockCanInstall,
+    platform: mockPlatform,
+    promptInstall: mockPromptInstall,
+    dismiss: mockDismiss,
+  }),
+}));
+
+let InstallBanner: typeof import('../../../src/components/pwa/InstallBanner').InstallBanner;
+
+beforeAll(async () => {
+  const mod = await import('../../../src/components/pwa/InstallBanner');
+  InstallBanner = mod.InstallBanner;
+});
+
+describe('InstallBanner', () => {
+  beforeEach(() => {
+    mockCanInstall = false;
+    mockPlatform = null;
+    mockPromptInstall.mockClear();
+    mockDismiss.mockClear();
+  });
+
+  it('renders nothing when canInstall is false', () => {
+    const { container } = render(<InstallBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders install banner for Chromium with install button', () => {
+    mockCanInstall = true;
+    mockPlatform = 'chromium';
+    render(<InstallBanner />);
+
+    expect(screen.getByText(/install safeclaw/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
+  });
+
+  it('calls promptInstall when install button is clicked on Chromium', async () => {
+    mockCanInstall = true;
+    mockPlatform = 'chromium';
+    mockPromptInstall.mockResolvedValue('accepted');
+    render(<InstallBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    expect(mockPromptInstall).toHaveBeenCalled();
+  });
+
+  it('renders iOS instructions when platform is ios', () => {
+    mockCanInstall = true;
+    mockPlatform = 'ios';
+    render(<InstallBanner />);
+
+    expect(screen.getByText(/install safeclaw/i)).toBeInTheDocument();
+    // Should show iOS-specific guidance mentioning Share button
+    expect(screen.getByText(/share/i)).toBeInTheDocument();
+    expect(screen.getByText(/add to home screen/i)).toBeInTheDocument();
+  });
+
+  it('calls dismiss when close button is clicked', async () => {
+    mockCanInstall = true;
+    mockPlatform = 'chromium';
+    render(<InstallBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(mockDismiss).toHaveBeenCalled();
+  });
+});

--- a/tests/components/pwa/UpdateToast.test.tsx
+++ b/tests/components/pwa/UpdateToast.test.tsx
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// UpdateToast component tests
+// ---------------------------------------------------------------------------
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock the usePwaUpdate hook
+const mockUpdateServiceWorker = vi.fn().mockResolvedValue(undefined);
+const mockDismissUpdate = vi.fn();
+let mockNeedRefresh = false;
+let mockOfflineReady = false;
+
+vi.mock('../../../src/hooks/use-pwa-update.js', () => ({
+  usePwaUpdate: () => ({
+    needRefresh: mockNeedRefresh,
+    offlineReady: mockOfflineReady,
+    updateServiceWorker: mockUpdateServiceWorker,
+    dismissUpdate: mockDismissUpdate,
+  }),
+}));
+
+let UpdateToast: typeof import('../../../src/components/pwa/UpdateToast').UpdateToast;
+
+beforeAll(async () => {
+  const mod = await import('../../../src/components/pwa/UpdateToast');
+  UpdateToast = mod.UpdateToast;
+});
+
+describe('UpdateToast', () => {
+  beforeEach(() => {
+    mockNeedRefresh = false;
+    mockOfflineReady = false;
+    mockUpdateServiceWorker.mockClear();
+    mockDismissUpdate.mockClear();
+  });
+
+  it('renders nothing when no update is needed and not offline ready', () => {
+    const { container } = render(<UpdateToast />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders update toast when needRefresh is true', () => {
+    mockNeedRefresh = true;
+    render(<UpdateToast />);
+
+    expect(screen.getByText(/new version available/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('calls updateServiceWorker when reload button is clicked', async () => {
+    mockNeedRefresh = true;
+    render(<UpdateToast />);
+
+    await userEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(mockUpdateServiceWorker).toHaveBeenCalled();
+  });
+
+  it('calls dismissUpdate when dismiss button is clicked', async () => {
+    mockNeedRefresh = true;
+    render(<UpdateToast />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(mockDismissUpdate).toHaveBeenCalled();
+  });
+
+  it('renders offline ready toast when offlineReady is true', () => {
+    mockOfflineReady = true;
+    render(<UpdateToast />);
+
+    expect(screen.getByText(/ready to work offline/i)).toBeInTheDocument();
+  });
+
+  it('dismiss on offline ready toast calls dismissUpdate', async () => {
+    mockOfflineReady = true;
+    render(<UpdateToast />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(mockDismissUpdate).toHaveBeenCalled();
+  });
+});

--- a/tests/hooks/use-pwa-install.test.ts
+++ b/tests/hooks/use-pwa-install.test.ts
@@ -1,0 +1,199 @@
+// ---------------------------------------------------------------------------
+// usePwaInstall hook tests
+// ---------------------------------------------------------------------------
+
+import { renderHook, act } from '@testing-library/react';
+
+// We need to dynamically import the hook after setting up mocks
+let usePwaInstall: typeof import('../../src/hooks/use-pwa-install').usePwaInstall;
+
+beforeAll(async () => {
+  const mod = await import('../../src/hooks/use-pwa-install');
+  usePwaInstall = mod.usePwaInstall;
+});
+
+describe('usePwaInstall', () => {
+  let originalUserAgent: string;
+
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      writable: true,
+      configurable: true,
+    });
+    // Clean up standalone property
+    if ('standalone' in navigator) {
+      Object.defineProperty(navigator, 'standalone', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it('starts with canInstall false and no platform', () => {
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.canInstall).toBe(false);
+    expect(result.current.platform).toBeNull();
+  });
+
+  it('captures beforeinstallprompt event on Chromium browsers', () => {
+    const { result } = renderHook(() => usePwaInstall());
+
+    const mockPrompt = vi.fn().mockResolvedValue({ outcome: 'accepted' });
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: () => Promise<{ outcome: string }>;
+      preventDefault: () => void;
+    };
+    Object.defineProperty(event, 'prompt', { value: mockPrompt });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current.canInstall).toBe(true);
+    expect(result.current.platform).toBe('chromium');
+  });
+
+  it('detects iOS Safari when navigator.standalone is undefined and UA matches iPhone', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'standalone', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    // Need to re-render to re-evaluate iOS detection
+    const { result } = renderHook(() => usePwaInstall());
+
+    // iOS detection happens on mount — since standalone is undefined and UA matches iOS
+    // But the hook should check navigator.standalone === undefined (not in standalone mode)
+    // and the iOS user agent pattern
+    expect(result.current.platform).toBe('ios');
+    expect(result.current.canInstall).toBe(true);
+  });
+
+  it('detects iOS Safari with iPad user agent', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)',
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'standalone', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.platform).toBe('ios');
+    expect(result.current.canInstall).toBe(true);
+  });
+
+  it('does not show install on iOS when already in standalone mode', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'standalone', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePwaInstall());
+    // Already installed — should not show install prompt
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('promptInstall calls the deferred prompt on Chromium', async () => {
+    const { result } = renderHook(() => usePwaInstall());
+
+    const mockPrompt = vi.fn().mockResolvedValue({ outcome: 'accepted' });
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: () => Promise<{ outcome: string }>;
+    };
+    Object.defineProperty(event, 'prompt', { value: mockPrompt });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.promptInstall();
+    });
+
+    expect(mockPrompt).toHaveBeenCalled();
+    expect(outcome).toBe('accepted');
+  });
+
+  it('promptInstall returns undefined when no deferred prompt exists', async () => {
+    const { result } = renderHook(() => usePwaInstall());
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.promptInstall();
+    });
+
+    expect(outcome).toBeUndefined();
+  });
+
+  it('resets canInstall after prompt is used (accepted)', async () => {
+    const { result } = renderHook(() => usePwaInstall());
+
+    const mockPrompt = vi.fn().mockResolvedValue({ outcome: 'accepted' });
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: () => Promise<{ outcome: string }>;
+    };
+    Object.defineProperty(event, 'prompt', { value: mockPrompt });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    expect(result.current.canInstall).toBe(true);
+
+    await act(async () => {
+      await result.current.promptInstall();
+    });
+
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('dismiss sets canInstall to false', () => {
+    const { result } = renderHook(() => usePwaInstall());
+
+    const mockPrompt = vi.fn().mockResolvedValue({ outcome: 'accepted' });
+    const event = new Event('beforeinstallprompt') as Event & {
+      prompt: () => Promise<{ outcome: string }>;
+    };
+    Object.defineProperty(event, 'prompt', { value: mockPrompt });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    expect(result.current.canInstall).toBe(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('cleans up event listener on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => usePwaInstall());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('beforeinstallprompt', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/tests/hooks/use-pwa-update.test.ts
+++ b/tests/hooks/use-pwa-update.test.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// usePwaUpdate hook tests
+// ---------------------------------------------------------------------------
+
+import { renderHook, act } from '@testing-library/react';
+
+// Mock virtual:pwa-register module
+const mockUpdateSW = vi.fn().mockResolvedValue(undefined);
+let capturedOnNeedRefresh: ((value: boolean) => void) | null = null;
+let capturedOnRegisteredSW: ((swUrl: string, registration: ServiceWorkerRegistration | undefined) => void) | null = null;
+
+vi.mock('virtual:pwa-register', () => ({
+  registerSW: (opts: {
+    onNeedRefresh?: () => void;
+    onOfflineReady?: () => void;
+    onRegisteredSW?: (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+  }) => {
+    // Capture callbacks for test control
+    if (opts.onNeedRefresh) {
+      capturedOnNeedRefresh = opts.onNeedRefresh as unknown as (value: boolean) => void;
+    }
+    if (opts.onRegisteredSW) {
+      capturedOnRegisteredSW = opts.onRegisteredSW as unknown as (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+    }
+    return mockUpdateSW;
+  },
+}));
+
+let usePwaUpdate: typeof import('../../src/hooks/use-pwa-update').usePwaUpdate;
+
+beforeAll(async () => {
+  const mod = await import('../../src/hooks/use-pwa-update');
+  usePwaUpdate = mod.usePwaUpdate;
+});
+
+describe('usePwaUpdate', () => {
+  beforeEach(() => {
+    mockUpdateSW.mockClear();
+    capturedOnNeedRefresh = null;
+    capturedOnRegisteredSW = null;
+  });
+
+  it('starts with needRefresh false and offlineReady false', () => {
+    const { result } = renderHook(() => usePwaUpdate());
+    expect(result.current.needRefresh).toBe(false);
+    expect(result.current.offlineReady).toBe(false);
+  });
+
+  it('sets needRefresh to true when onNeedRefresh is called', () => {
+    const { result } = renderHook(() => usePwaUpdate());
+
+    expect(capturedOnNeedRefresh).toBeTruthy();
+    act(() => {
+      capturedOnNeedRefresh!(true);
+    });
+
+    expect(result.current.needRefresh).toBe(true);
+  });
+
+  it('updateServiceWorker calls the registered update function', async () => {
+    const { result } = renderHook(() => usePwaUpdate());
+
+    await act(async () => {
+      await result.current.updateServiceWorker();
+    });
+
+    expect(mockUpdateSW).toHaveBeenCalledWith(true);
+  });
+
+  it('dismissUpdate resets needRefresh to false', () => {
+    const { result } = renderHook(() => usePwaUpdate());
+
+    act(() => {
+      capturedOnNeedRefresh!(true);
+    });
+    expect(result.current.needRefresh).toBe(true);
+
+    act(() => {
+      result.current.dismissUpdate();
+    });
+    expect(result.current.needRefresh).toBe(false);
+  });
+});

--- a/tests/mocks/virtual-pwa-register.ts
+++ b/tests/mocks/virtual-pwa-register.ts
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------------------
+// Mock for virtual:pwa-register (vite-plugin-pwa virtual module)
+// ---------------------------------------------------------------------------
+
+export interface RegisterSWOptions {
+  onNeedRefresh?: () => void;
+  onOfflineReady?: () => void;
+  onRegisteredSW?: (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+}
+
+export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void> {
+  if (options?.onRegisteredSW) {
+    options.onRegisteredSW('', undefined);
+  }
+  return async (_reloadPage?: boolean) => {};
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/vanillajs" />
 
 // OPFS types not yet in standard lib
 interface FileSystemDirectoryHandle {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
       },
       workbox: {
         maximumFileSizeToCacheInBytes: 8 * 1024 * 1024, // 8 MiB — WebLLM bundle is ~6 MiB
+        navigateFallback: '/index.html',
+        navigateFallbackDenylist: [/^\/api/],
       },
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,11 @@ export default defineConfig({
       '../db.js': path.resolve(__dirname, 'src/db.ts'),
       '../orchestrator.js': path.resolve(__dirname, 'src/orchestrator.ts'),
       './agent-worker.js': path.resolve(__dirname, 'src/agent-worker.ts'),
+      '../../hooks/use-pwa-install.js': path.resolve(__dirname, 'src/hooks/use-pwa-install.ts'),
+      '../../hooks/use-pwa-update.js': path.resolve(__dirname, 'src/hooks/use-pwa-update.ts'),
+      '../pwa/InstallBanner.js': path.resolve(__dirname, 'src/components/pwa/InstallBanner.tsx'),
+      '../pwa/UpdateToast.js': path.resolve(__dirname, 'src/components/pwa/UpdateToast.tsx'),
+      'virtual:pwa-register': path.resolve(__dirname, 'tests/mocks/virtual-pwa-register.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
Adds Progressive Web App (PWA) support with install prompts and update notifications. This includes hooks for managing PWA lifecycle events, UI components for displaying install banners and update toasts, and comprehensive test coverage.

## Key Changes

- **PWA Install Hook** (`use-pwa-install.ts`): Manages the beforeinstallprompt event for Chromium browsers and detects iOS Safari for manual installation guidance. Provides `canInstall`, `platform`, `promptInstall()`, and `dismiss()` state/methods.

- **PWA Update Hook** (`use-pwa-update.ts`): Integrates with vite-plugin-pwa's registerSW to track service worker updates and offline readiness. Exposes `needRefresh`, `offlineReady`, `updateServiceWorker()`, and `dismissUpdate()`.

- **Install Banner Component** (`InstallBanner.tsx`): Displays platform-specific installation UI—shows a native install button for Chromium and iOS-specific instructions (Share → Add to Home Screen) for Safari.

- **Update Toast Component** (`UpdateToast.tsx`): Shows notifications for available updates and offline readiness with reload and dismiss actions.

- **Layout Integration**: Added InstallBanner and UpdateToast components to the main Layout to display PWA prompts throughout the app.

- **Vite Configuration**: Updated vite.config.ts with workbox settings for proper PWA navigation fallback behavior.

- **Comprehensive Tests**: Added full test suites for both hooks and components, including iOS/Chromium detection, event handling, and user interactions.

## Implementation Details

- iOS detection checks for iPhone/iPad/iPod user agents and verifies `navigator.standalone !== true` to avoid showing prompts when already installed
- Chromium support uses the standard beforeinstallprompt event with proper cleanup on unmount
- Service worker updates are managed through vite-plugin-pwa's virtual module with proper state management
- All components gracefully render nothing when no action is needed (canInstall/needRefresh false)

https://claude.ai/code/session_01W6jcFuYJ8gNmSifHZXRUae