### PR TITLE
Add showBanner state and platform detection for PWA install

### DIFF
--- a/src/components/pwa/InstallBanner.tsx
+++ b/src/components/pwa/InstallBanner.tsx
@@ -2,13 +2,35 @@
 // SafeClaw — PWA Install Banner
 // ---------------------------------------------------------------------------
 
-import { Download, Share, X } from 'lucide-react';
+import { AlertTriangle, Download, Share, X } from 'lucide-react';
 import { usePwaInstall } from '../../hooks/use-pwa-install.js';
 
 export function InstallBanner() {
-  const { canInstall, platform, promptInstall, dismiss } = usePwaInstall();
+  const { canInstall, showBanner, platform, promptInstall, dismiss } = usePwaInstall();
 
-  if (!canInstall) return null;
+  if (!showBanner) return null;
+
+  if (platform === 'unsupported') {
+    return (
+      <div className="alert alert-warning shadow-lg mx-4 mt-2" role="alert">
+        <AlertTriangle className="w-5 h-5 shrink-0" />
+        <div className="flex-1">
+          <h3 className="font-bold text-sm">Chrome Required</h3>
+          <p className="text-xs">
+            SafeClaw is compatible only with Chrome. Please open this page in Chrome to
+            install and use the app.
+          </p>
+        </div>
+        <button
+          className="btn btn-sm btn-ghost"
+          onClick={dismiss}
+          aria-label="Dismiss install banner"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="alert alert-info shadow-lg mx-4 mt-2" role="alert">
@@ -25,7 +47,7 @@ export function InstallBanner() {
         )}
       </div>
       <div className="flex gap-1">
-        {platform === 'chromium' && (
+        {canInstall && platform === 'chromium' && (
           <button
             className="btn btn-sm btn-primary"
             onClick={promptInstall}

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -8,10 +8,11 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<{ outcome: 'accepted' | 'dismissed' }>;
 }
 
-type Platform = 'chromium' | 'ios' | null;
+type Platform = 'chromium' | 'ios' | 'unsupported' | null;
 
 interface PwaInstallState {
   canInstall: boolean;
+  showBanner: boolean;
   platform: Platform;
   promptInstall: () => Promise<string | undefined>;
   dismiss: () => void;
@@ -25,13 +26,36 @@ function detectIos(): boolean {
   return isIosUA && isStandalone !== true;
 }
 
+function isIosStandalone(): boolean {
+  const isIosUA = /iPhone|iPad|iPod/.test(navigator.userAgent);
+  const isStandalone = (navigator as Navigator & { standalone?: boolean }).standalone;
+  return isIosUA && isStandalone === true;
+}
+
+function isRunningStandalone(): boolean {
+  if (isIosStandalone()) return true;
+  return window.matchMedia('(display-mode: standalone)').matches;
+}
+
+function detectInitialPlatform(): Platform {
+  if (detectIos()) return 'ios';
+  // Non-iOS, non-standalone: detect if Chromium-based via chrome global or UA
+  // Chromium browsers will fire beforeinstallprompt later; for now detect unsupported
+  const ua = navigator.userAgent;
+  const isChromium = /Chrome\//.test(ua) && !/Edg\/|OPR\//.test(ua) || /CriOS/.test(ua);
+  const isEdgeChromium = /Edg\//.test(ua);
+  const isOpera = /OPR\//.test(ua);
+  if (isChromium || isEdgeChromium || isOpera) return null; // Chromium-based, will get platform from beforeinstallprompt
+  return 'unsupported';
+}
+
 export function usePwaInstall(): PwaInstallState {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [platform, setPlatform] = useState<Platform>(() => {
-    if (detectIos()) return 'ios';
-    return null;
-  });
+  const [platform, setPlatform] = useState<Platform>(() => detectInitialPlatform());
   const [canInstall, setCanInstall] = useState<boolean>(() => detectIos());
+  const [dismissed, setDismissed] = useState(false);
+
+  const standalone = isRunningStandalone();
 
   useEffect(() => {
     function handleBeforeInstall(e: Event) {
@@ -57,7 +81,10 @@ export function usePwaInstall(): PwaInstallState {
 
   const dismiss = useCallback(() => {
     setCanInstall(false);
+    setDismissed(true);
   }, []);
 
-  return { canInstall, platform, promptInstall, dismiss };
+  const showBanner = !standalone && !dismissed;
+
+  return { canInstall, showBanner, platform, promptInstall, dismiss };
 }

--- a/tests/components/pwa/InstallBanner.test.tsx
+++ b/tests/components/pwa/InstallBanner.test.tsx
@@ -9,11 +9,13 @@ import userEvent from '@testing-library/user-event';
 const mockPromptInstall = vi.fn();
 const mockDismiss = vi.fn();
 let mockCanInstall = false;
-let mockPlatform: 'chromium' | 'ios' | null = null;
+let mockShowBanner = false;
+let mockPlatform: 'chromium' | 'ios' | 'unsupported' | null = null;
 
 vi.mock('../../../src/hooks/use-pwa-install.js', () => ({
   usePwaInstall: () => ({
     canInstall: mockCanInstall,
+    showBanner: mockShowBanner,
     platform: mockPlatform,
     promptInstall: mockPromptInstall,
     dismiss: mockDismiss,
@@ -30,18 +32,20 @@ beforeAll(async () => {
 describe('InstallBanner', () => {
   beforeEach(() => {
     mockCanInstall = false;
+    mockShowBanner = false;
     mockPlatform = null;
     mockPromptInstall.mockClear();
     mockDismiss.mockClear();
   });
 
-  it('renders nothing when canInstall is false', () => {
+  it('renders nothing when showBanner is false', () => {
     const { container } = render(<InstallBanner />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders install banner for Chromium with install button', () => {
+  it('renders install banner for Chromium with install button when canInstall', () => {
     mockCanInstall = true;
+    mockShowBanner = true;
     mockPlatform = 'chromium';
     render(<InstallBanner />);
 
@@ -49,8 +53,19 @@ describe('InstallBanner', () => {
     expect(screen.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
   });
 
+  it('renders Chromium banner without install button when canInstall is false', () => {
+    mockCanInstall = false;
+    mockShowBanner = true;
+    mockPlatform = 'chromium';
+    render(<InstallBanner />);
+
+    expect(screen.getByText(/install safeclaw/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
+  });
+
   it('calls promptInstall when install button is clicked on Chromium', async () => {
     mockCanInstall = true;
+    mockShowBanner = true;
     mockPlatform = 'chromium';
     mockPromptInstall.mockResolvedValue('accepted');
     render(<InstallBanner />);
@@ -61,6 +76,7 @@ describe('InstallBanner', () => {
 
   it('renders iOS instructions when platform is ios', () => {
     mockCanInstall = true;
+    mockShowBanner = true;
     mockPlatform = 'ios';
     render(<InstallBanner />);
 
@@ -70,9 +86,31 @@ describe('InstallBanner', () => {
     expect(screen.getByText(/add to home screen/i)).toBeInTheDocument();
   });
 
+  it('renders unsupported browser message for non-Chrome browsers', () => {
+    mockCanInstall = false;
+    mockShowBanner = true;
+    mockPlatform = 'unsupported';
+    render(<InstallBanner />);
+
+    expect(screen.getByText(/chrome required/i)).toBeInTheDocument();
+    // Should not show install button for unsupported browsers
+    expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
+  });
+
   it('calls dismiss when close button is clicked', async () => {
     mockCanInstall = true;
+    mockShowBanner = true;
     mockPlatform = 'chromium';
+    render(<InstallBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(mockDismiss).toHaveBeenCalled();
+  });
+
+  it('shows dismiss button for unsupported browser banner', async () => {
+    mockCanInstall = false;
+    mockShowBanner = true;
+    mockPlatform = 'unsupported';
     render(<InstallBanner />);
 
     await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));

--- a/tests/hooks/use-pwa-install.test.ts
+++ b/tests/hooks/use-pwa-install.test.ts
@@ -14,9 +14,11 @@ beforeAll(async () => {
 
 describe('usePwaInstall', () => {
   let originalUserAgent: string;
+  let originalMatchMedia: typeof window.matchMedia;
 
   beforeEach(() => {
     originalUserAgent = navigator.userAgent;
+    originalMatchMedia = window.matchMedia;
   });
 
   afterEach(() => {
@@ -33,12 +35,39 @@ describe('usePwaInstall', () => {
         configurable: true,
       });
     }
+    window.matchMedia = originalMatchMedia;
   });
 
-  it('starts with canInstall false and no platform', () => {
+  it('starts with canInstall false and showBanner true on desktop Chrome UA', () => {
+    // Default happy-dom UA is not iOS and not standalone, so showBanner = true
     const { result } = renderHook(() => usePwaInstall());
     expect(result.current.canInstall).toBe(false);
-    expect(result.current.platform).toBeNull();
+    expect(result.current.showBanner).toBe(true);
+  });
+
+  it('detects unsupported platform for Firefox user agent', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/119.0',
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.platform).toBe('unsupported');
+    expect(result.current.showBanner).toBe(true);
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('detects unsupported platform for Safari on macOS', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.platform).toBe('unsupported');
+    expect(result.current.showBanner).toBe(true);
   });
 
   it('captures beforeinstallprompt event on Chromium browsers', () => {
@@ -57,6 +86,7 @@ describe('usePwaInstall', () => {
 
     expect(result.current.canInstall).toBe(true);
     expect(result.current.platform).toBe('chromium');
+    expect(result.current.showBanner).toBe(true);
   });
 
   it('detects iOS Safari when navigator.standalone is undefined and UA matches iPhone', () => {
@@ -79,6 +109,7 @@ describe('usePwaInstall', () => {
     // and the iOS user agent pattern
     expect(result.current.platform).toBe('ios');
     expect(result.current.canInstall).toBe(true);
+    expect(result.current.showBanner).toBe(true);
   });
 
   it('detects iOS Safari with iPad user agent', () => {
@@ -96,6 +127,7 @@ describe('usePwaInstall', () => {
     const { result } = renderHook(() => usePwaInstall());
     expect(result.current.platform).toBe('ios');
     expect(result.current.canInstall).toBe(true);
+    expect(result.current.showBanner).toBe(true);
   });
 
   it('does not show install on iOS when already in standalone mode', () => {
@@ -113,6 +145,23 @@ describe('usePwaInstall', () => {
     const { result } = renderHook(() => usePwaInstall());
     // Already installed — should not show install prompt
     expect(result.current.canInstall).toBe(false);
+    expect(result.current.showBanner).toBe(false);
+  });
+
+  it('hides banner when running in standalone display mode', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(display-mode: standalone)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.showBanner).toBe(false);
   });
 
   it('promptInstall calls the deferred prompt on Chromium', async () => {
@@ -169,7 +218,7 @@ describe('usePwaInstall', () => {
     expect(result.current.canInstall).toBe(false);
   });
 
-  it('dismiss sets canInstall to false', () => {
+  it('dismiss sets canInstall to false and showBanner to false', () => {
     const { result } = renderHook(() => usePwaInstall());
 
     const mockPrompt = vi.fn().mockResolvedValue({ outcome: 'accepted' });
@@ -182,11 +231,13 @@ describe('usePwaInstall', () => {
       window.dispatchEvent(event);
     });
     expect(result.current.canInstall).toBe(true);
+    expect(result.current.showBanner).toBe(true);
 
     act(() => {
       result.current.dismiss();
     });
     expect(result.current.canInstall).toBe(false);
+    expect(result.current.showBanner).toBe(false);
   });
 
   it('cleans up event listener on unmount', () => {


### PR DESCRIPTION
## Summary
This PR enhances the PWA install banner functionality by introducing a `showBanner` state to control banner visibility independently from `canInstall`, and adds detection for unsupported browsers (Firefox, Safari) to provide appropriate messaging.

## Key Changes

- **New `showBanner` state**: Separates banner visibility logic from install capability. The banner is hidden when:
  - The app is running in standalone display mode
  - The user has dismissed the banner
  
- **Platform detection improvements**:
  - Added `'unsupported'` as a new platform type for non-Chromium browsers
  - Implemented `detectInitialPlatform()` to identify Firefox, Safari, and other unsupported browsers on initial load
  - Added `isRunningStandalone()` to detect both iOS standalone mode and PWA standalone display mode via `matchMedia`

- **InstallBanner component updates**:
  - Now renders a "Chrome Required" warning message for unsupported browsers
  - Shows install button only when `canInstall` is true (not just when platform is chromium)
  - Allows dismissal of unsupported browser warnings
  - Uses `showBanner` to control overall visibility instead of `canInstall`

- **State management**:
  - Added `dismissed` state to track user dismissals
  - Properly restores `window.matchMedia` in test cleanup

## Implementation Details

- The `showBanner` logic is: `!standalone && !dismissed`
- Platform detection happens at hook initialization and can be updated via `beforeinstallprompt` event
- Tests now verify both `canInstall` and `showBanner` states across different scenarios
- Component gracefully handles all platform types with appropriate UI and messaging

https://claude.ai/code/session_01BsRs6hmUhaa6PoBgdsoCXe