### PR TITLE
Add version checker and VersionSection component

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -407,7 +407,7 @@
 
   <!-- Hero -->
   <section class="hero">
-    <div class="hero-badge">🔒 100% Browser-Native — No Server Required</div>
+    <div class="hero-badge">🔒 100% Browser-Native — No Server Required · v2.0.0</div>
     <h1>
       <span class="gradient">Browser-Native</span><br />
       Personal AI Assistant
@@ -726,6 +726,7 @@
   <!-- Footer -->
   <footer>
     <p>🛡️ <strong>SafeClaw</strong> — Browser-native personal AI assistant with multi-provider LLM support.</p>
+    <p style="margin-top: 0.5rem; font-size: 0.85rem; color: var(--text-secondary);">Latest release: v2.0.0 · March 2026</p>
     <p class="attribution">
       SafeClaw is a fork of <a href="https://github.com/sachaa/openbrowserclaw">OpenBrowserClaw</a> by sachaa. Licensed under MIT.
     </p>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { getOrchestrator, useOrchestratorStore } from '../../stores/orchestrator
 import { useThemeStore, type ThemeChoice } from '../../stores/theme-store.js';
 import type { ProviderId, LocalPreference } from '../../providers/types.js';
 import { ProfileSection } from './ProfileSection.js';
+import { VersionSection } from './VersionSection.js';
 
 // ---------------------------------------------------------------------------
 // Provider / model definitions
@@ -540,6 +541,9 @@ export function SettingsPage() {
           )}
         </div>
       </div>
+
+      {/* ---- Version ---- */}
+      <VersionSection />
     </div>
   );
 }

--- a/src/components/settings/VersionSection.tsx
+++ b/src/components/settings/VersionSection.tsx
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — Version section for settings
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useState } from 'react';
+import { Info, CheckCircle, AlertTriangle, RefreshCw } from 'lucide-react';
+import { APP_VERSION } from '../../config.js';
+import { checkLatestVersion } from '../../version-checker.js';
+import type { VersionStatus } from '../../version-checker.js';
+
+export function VersionSection() {
+  const [status, setStatus] = useState<VersionStatus | null>(null);
+  const [checking, setChecking] = useState(true);
+
+  const runCheck = useCallback(async () => {
+    setChecking(true);
+    const result = await checkLatestVersion(APP_VERSION);
+    setStatus(result);
+    setChecking(false);
+  }, []);
+
+  useEffect(() => {
+    runCheck();
+  }, [runCheck]);
+
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  return (
+    <div className="card card-bordered bg-base-200">
+      <div className="card-body p-4 sm:p-6 gap-3">
+        <h3 className="card-title text-base gap-2"><Info className="w-4 h-4" /> Version</h3>
+
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-mono font-semibold">v{APP_VERSION}</span>
+        </div>
+
+        {checking && (
+          <div className="flex items-center gap-2 text-sm opacity-60">
+            <RefreshCw className="w-4 h-4 animate-spin" />
+            <span>Checking for updates...</span>
+          </div>
+        )}
+
+        {!checking && status?.isUpToDate === true && (
+          <div className="flex items-center gap-2">
+            <div className="badge badge-success badge-sm gap-1.5">
+              <CheckCircle className="w-3 h-3" />
+              You're on the latest version
+            </div>
+            {status.latestDate && (
+              <span className="text-xs opacity-60">
+                Released {formatDate(status.latestDate)}
+              </span>
+            )}
+          </div>
+        )}
+
+        {!checking && status?.isUpToDate === false && (
+          <div className="space-y-1">
+            <div className="badge badge-warning badge-sm gap-1.5">
+              <AlertTriangle className="w-3 h-3" />
+              Update available — v{status.latest}
+            </div>
+            {status.latestDate && (
+              <p className="text-xs opacity-60">
+                Released {formatDate(status.latestDate)}
+              </p>
+            )}
+            <p className="text-xs opacity-50">
+              Reload the page or reinstall the PWA to get the latest version.
+            </p>
+          </div>
+        )}
+
+        {!checking && status?.error && (
+          <p className="text-xs text-error opacity-70">
+            Could not check for updates: {status.error}
+          </p>
+        )}
+
+        {!checking && (
+          <button
+            className="btn btn-ghost btn-xs gap-1 w-fit"
+            onClick={runCheck}
+            aria-label="Check again"
+          >
+            <RefreshCw className="w-3 h-3" />
+            Check again
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,9 @@
 // SafeClaw — Configuration constants
 // ---------------------------------------------------------------------------
 
+/** Application version (injected at build time from package.json) */
+export const APP_VERSION: string = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0';
+
 /** Default assistant name (used in trigger pattern) */
 export const ASSISTANT_NAME = 'Andy';
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/src/version-checker.ts
+++ b/src/version-checker.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — Runtime version checker (GitHub Releases API)
+// ---------------------------------------------------------------------------
+
+export interface VersionStatus {
+  current: string;
+  latest: string | null;
+  latestDate: string | null;
+  isUpToDate: boolean | null;
+  error: string | null;
+}
+
+export const GITHUB_RELEASES_URL =
+  'https://api.github.com/repos/renato-umeton/safeclaw/releases/latest';
+
+/** Compare two semver strings. Returns -1 if a < b, 0 if equal, 1 if a > b. */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] > pb[i]) return 1;
+    if (pa[i] < pb[i]) return -1;
+  }
+  return 0;
+}
+
+/** Fetch the latest release from GitHub and compare against the current version. */
+export async function checkLatestVersion(currentVersion: string): Promise<VersionStatus> {
+  try {
+    const resp = await fetch(GITHUB_RELEASES_URL);
+    if (!resp.ok) {
+      return {
+        current: currentVersion,
+        latest: null,
+        latestDate: null,
+        isUpToDate: null,
+        error: `GitHub API returned ${resp.status}`,
+      };
+    }
+
+    const data = await resp.json();
+    const tagName: string = data.tag_name ?? '';
+    const latest = tagName.replace(/^v/, '');
+    const latestDate: string | null = data.published_at ?? null;
+
+    return {
+      current: currentVersion,
+      latest,
+      latestDate,
+      isUpToDate: compareSemver(currentVersion, latest) >= 0,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      current: currentVersion,
+      latest: null,
+      latestDate: null,
+      isUpToDate: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -76,6 +76,11 @@ vi.mock('../../../src/crypto', () => ({
   decryptValue: vi.fn().mockResolvedValue(''),
 }));
 
+// Mock VersionSection to avoid fetch calls in SettingsPage tests
+vi.mock('../../../src/components/settings/VersionSection', () => ({
+  VersionSection: () => <div data-testid="version-section">Version</div>,
+}));
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -106,6 +111,7 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Your Profile')).toBeInTheDocument();
     expect(screen.getByText('Telegram Bot')).toBeInTheDocument();
     expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.getByText('Version')).toBeInTheDocument();
   });
 
   // ---- Theme selection ----

--- a/tests/components/settings/VersionSection.test.tsx
+++ b/tests/components/settings/VersionSection.test.tsx
@@ -1,0 +1,184 @@
+// ---------------------------------------------------------------------------
+// VersionSection component tests
+// ---------------------------------------------------------------------------
+
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { VersionStatus } from '../../../src/version-checker';
+
+// Mock version-checker module
+const mockCheckLatestVersion = vi.fn<(v: string) => Promise<VersionStatus>>();
+
+vi.mock('../../../src/version-checker', () => ({
+  checkLatestVersion: (v: string) => mockCheckLatestVersion(v),
+}));
+
+// Mock config to provide APP_VERSION
+vi.mock('../../../src/config', async () => {
+  const actual = await vi.importActual('../../../src/config');
+  return { ...actual, APP_VERSION: '2.0.0' };
+});
+
+let VersionSection: typeof import('../../../src/components/settings/VersionSection').VersionSection;
+
+beforeAll(async () => {
+  const mod = await import('../../../src/components/settings/VersionSection');
+  VersionSection = mod.VersionSection;
+});
+
+describe('VersionSection', () => {
+  beforeEach(() => {
+    mockCheckLatestVersion.mockReset();
+  });
+
+  it('renders Version heading', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.0.0',
+      latestDate: '2026-03-01T00:00:00Z',
+      isUpToDate: true,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    expect(screen.getByText('Version')).toBeInTheDocument();
+  });
+
+  it('shows current version', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.0.0',
+      latestDate: null,
+      isUpToDate: true,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/v2\.0\.0/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state while checking', async () => {
+    // Never resolve the promise to keep loading state
+    mockCheckLatestVersion.mockReturnValue(new Promise(() => {}));
+
+    render(<VersionSection />);
+
+    expect(screen.getByText(/checking/i)).toBeInTheDocument();
+  });
+
+  it('shows up-to-date message when versions match', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.0.0',
+      latestDate: '2026-03-01T00:00:00Z',
+      isUpToDate: true,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/latest version/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows update available message when behind', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.1.0',
+      latestDate: '2026-03-05T00:00:00Z',
+      isUpToDate: false,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/update available/i)).toBeInTheDocument();
+      expect(screen.getByText(/v2\.1\.0/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when check fails', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: null,
+      latestDate: null,
+      isUpToDate: null,
+      error: 'Network error',
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not check/i)).toBeInTheDocument();
+    });
+  });
+
+  it('check again button triggers a new check', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.0.0',
+      latestDate: null,
+      isUpToDate: true,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/latest version/i)).toBeInTheDocument();
+    });
+
+    expect(mockCheckLatestVersion).toHaveBeenCalledTimes(1);
+
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.1.0',
+      latestDate: null,
+      isUpToDate: false,
+      error: null,
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /check again/i }));
+    });
+
+    expect(mockCheckLatestVersion).toHaveBeenCalledTimes(2);
+  });
+
+  it('displays release date when available', async () => {
+    mockCheckLatestVersion.mockResolvedValue({
+      current: '2.0.0',
+      latest: '2.0.0',
+      latestDate: '2026-03-09T12:00:00Z',
+      isUpToDate: true,
+      error: null,
+    });
+
+    await act(async () => {
+      render(<VersionSection />);
+    });
+
+    await waitFor(() => {
+      // Should show a formatted date
+      expect(screen.getByText(/Mar/)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,6 +23,7 @@ import {
   CONFIG_KEYS,
   APP_URL,
   WEBSITE_URL,
+  APP_VERSION,
 } from '../src/config';
 
 describe('config constants', () => {
@@ -49,6 +50,11 @@ describe('config constants', () => {
   it('has valid deployment URLs', () => {
     expect(APP_URL).toBe('https://app-safeclaw.umeton.com');
     expect(WEBSITE_URL).toBe('https://safeclaw.umeton.com');
+  });
+
+  it('exports APP_VERSION as a valid semver string', () => {
+    expect(typeof APP_VERSION).toBe('string');
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it('has sensible Telegram constants', () => {

--- a/tests/version-checker.test.ts
+++ b/tests/version-checker.test.ts
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// version-checker tests
+// ---------------------------------------------------------------------------
+
+import { compareSemver, checkLatestVersion, GITHUB_RELEASES_URL } from '../src/version-checker';
+import type { VersionStatus } from '../src/version-checker';
+
+describe('compareSemver', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('2.0.0', '2.0.0')).toBe(0);
+  });
+
+  it('returns 1 when a has higher major', () => {
+    expect(compareSemver('3.0.0', '2.0.0')).toBe(1);
+  });
+
+  it('returns -1 when a has lower major', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1);
+  });
+
+  it('compares minor when major is equal', () => {
+    expect(compareSemver('2.1.0', '2.0.0')).toBe(1);
+    expect(compareSemver('2.0.0', '2.1.0')).toBe(-1);
+  });
+
+  it('compares patch when major and minor are equal', () => {
+    expect(compareSemver('2.0.1', '2.0.0')).toBe(1);
+    expect(compareSemver('2.0.0', '2.0.1')).toBe(-1);
+  });
+
+  it('handles multi-digit version numbers', () => {
+    expect(compareSemver('2.10.0', '2.9.0')).toBe(1);
+    expect(compareSemver('12.0.0', '3.0.0')).toBe(1);
+  });
+});
+
+describe('checkLatestVersion', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockGitHubRelease(tagName: string, publishedAt: string) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        tag_name: tagName,
+        published_at: publishedAt,
+      }),
+    });
+  }
+
+  it('returns isUpToDate true when current matches latest', async () => {
+    mockGitHubRelease('v2.0.0', '2026-03-01T00:00:00Z');
+
+    const result = await checkLatestVersion('2.0.0');
+
+    expect(result.current).toBe('2.0.0');
+    expect(result.latest).toBe('2.0.0');
+    expect(result.latestDate).toBe('2026-03-01T00:00:00Z');
+    expect(result.isUpToDate).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns isUpToDate false when current is older', async () => {
+    mockGitHubRelease('v2.1.0', '2026-03-05T00:00:00Z');
+
+    const result = await checkLatestVersion('2.0.0');
+
+    expect(result.current).toBe('2.0.0');
+    expect(result.latest).toBe('2.1.0');
+    expect(result.isUpToDate).toBe(false);
+  });
+
+  it('returns isUpToDate true when current is newer (dev build)', async () => {
+    mockGitHubRelease('v2.0.0', '2026-03-01T00:00:00Z');
+
+    const result = await checkLatestVersion('2.1.0');
+
+    expect(result.isUpToDate).toBe(true);
+  });
+
+  it('strips v prefix from tag_name', async () => {
+    mockGitHubRelease('v3.2.1', '2026-03-01T00:00:00Z');
+
+    const result = await checkLatestVersion('3.2.1');
+
+    expect(result.latest).toBe('3.2.1');
+    expect(result.isUpToDate).toBe(true);
+  });
+
+  it('handles tag_name without v prefix', async () => {
+    mockGitHubRelease('3.0.0', '2026-03-01T00:00:00Z');
+
+    const result = await checkLatestVersion('3.0.0');
+
+    expect(result.latest).toBe('3.0.0');
+    expect(result.isUpToDate).toBe(true);
+  });
+
+  it('returns error when fetch fails', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const result = await checkLatestVersion('2.0.0');
+
+    expect(result.current).toBe('2.0.0');
+    expect(result.latest).toBeNull();
+    expect(result.latestDate).toBeNull();
+    expect(result.isUpToDate).toBeNull();
+    expect(result.error).toBe('Network error');
+  });
+
+  it('returns error when API returns non-200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const result = await checkLatestVersion('2.0.0');
+
+    expect(result.isUpToDate).toBeNull();
+    expect(result.error).toContain('404');
+  });
+
+  it('extracts published_at into latestDate', async () => {
+    mockGitHubRelease('v2.0.0', '2026-03-09T12:30:00Z');
+
+    const result = await checkLatestVersion('2.0.0');
+
+    expect(result.latestDate).toBe('2026-03-09T12:30:00Z');
+  });
+
+  it('calls the correct GitHub API URL', async () => {
+    mockGitHubRelease('v2.0.0', '2026-03-01T00:00:00Z');
+
+    await checkLatestVersion('2.0.0');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(GITHUB_RELEASES_URL);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import pkg from './package.json' with { type: 'json' };
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     react(),
     tailwindcss(),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('2.0.0'),
+  },
   resolve: {
     alias: {
       './storage.js': path.resolve(__dirname, 'src/storage.ts'),
@@ -37,6 +40,9 @@ export default defineConfig({
       '../../hooks/use-pwa-update.js': path.resolve(__dirname, 'src/hooks/use-pwa-update.ts'),
       '../pwa/InstallBanner.js': path.resolve(__dirname, 'src/components/pwa/InstallBanner.tsx'),
       '../pwa/UpdateToast.js': path.resolve(__dirname, 'src/components/pwa/UpdateToast.tsx'),
+      './VersionSection.js': path.resolve(__dirname, 'src/components/settings/VersionSection.tsx'),
+      '../../version-checker.js': path.resolve(__dirname, 'src/version-checker.ts'),
+      './version-checker.js': path.resolve(__dirname, 'src/version-checker.ts'),
       'virtual:pwa-register': path.resolve(__dirname, 'tests/mocks/virtual-pwa-register.ts'),
     },
   },


### PR DESCRIPTION
## Summary
This PR adds runtime version checking functionality to SafeClaw, allowing users to see their current version and check for available updates from GitHub Releases.

## Key Changes

- **Version Checker Module** (`src/version-checker.ts`):
  - New `checkLatestVersion()` function that fetches the latest release from GitHub API
  - `compareSemver()` utility for semantic version comparison
  - `VersionStatus` interface to represent version check results
  - Handles errors gracefully and returns structured status information

- **VersionSection Component** (`src/components/settings/VersionSection.tsx`):
  - New settings card component displaying current version
  - Shows loading state while checking for updates
  - Displays appropriate badges for up-to-date, update-available, and error states
  - Includes release date formatting and "Check again" button for manual refresh
  - Integrated into SettingsPage

- **Version Configuration**:
  - Added `APP_VERSION` export to `src/config.ts`
  - Configured Vite to inject version from `package.json` at build time via `__APP_VERSION__` global
  - Added TypeScript global declaration for `__APP_VERSION__`
  - Updated vitest config to define `__APP_VERSION__` for tests

- **Tests**:
  - Comprehensive test suite for `version-checker.ts` covering semver comparison and GitHub API integration
  - Full test coverage for `VersionSection` component including loading, success, error, and update states
  - Mocked VersionSection in SettingsPage tests to prevent fetch calls

- **Documentation**:
  - Updated website hero badge to display current version (v2.0.0)

## Implementation Details

- Version checking is performed on component mount and can be manually triggered
- GitHub API errors are caught and displayed to users without breaking the UI
- The component uses DaisyUI badges and Lucide icons for consistent styling
- Semantic version comparison correctly handles multi-digit version numbers
- Release dates are formatted using browser locale settings

https://claude.ai/code/session_011fSueUFNHNtJrsbQQFuMwT