### PR TITLE
Use package.json version for app version definition

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import pkg from './package.json' with { type: 'json' };
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify('2.0.0'),
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
Updated the Vitest configuration to dynamically reference the application version from `package.json` instead of maintaining a hardcoded version string.

## Key Changes
- Imported `package.json` using JSON import assertion in `vitest.config.ts`
- Changed `__APP_VERSION__` definition from hardcoded `'2.0.0'` to `pkg.version`

## Implementation Details
This change ensures the application version stays in sync with the version declared in `package.json`, eliminating the need to update the version in multiple places during releases. The version is now sourced from a single source of truth.

https://claude.ai/code/session_01MKWdTtXe1c1to5ocVYfRh3