### PR TITLE
Add support for smaller Qwen3 models in WebLLM provider

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -54,6 +54,8 @@ const PROVIDERS: ProviderInfo[] = [
     label: 'WebLLM (Local)',
     isLocal: true,
     models: [
+      { value: 'qwen3-0.6b', label: 'Qwen3 0.6B (400 MB)' },
+      { value: 'qwen3-1.7b', label: 'Qwen3 1.7B (1 GB)' },
       { value: 'qwen3-4b', label: 'Qwen3 4B (2.5 GB)' },
       { value: 'qwen3-30b', label: 'Qwen3 30B-A3B (16 GB)' },
     ],

--- a/src/providers/webllm.ts
+++ b/src/providers/webllm.ts
@@ -13,6 +13,8 @@ import type { ToolDefinition } from '../types.js';
 type WebLLMEngine = any;
 
 const WEBLLM_MODELS: Record<string, { contextWindow: number; mlcId: string }> = {
+  'qwen3-0.6b': { contextWindow: 32_768, mlcId: 'Qwen3-0.6B-q4f16_1-MLC' },
+  'qwen3-1.7b': { contextWindow: 32_768, mlcId: 'Qwen3-1.7B-q4f16_1-MLC' },
   'qwen3-4b': { contextWindow: 32_768, mlcId: 'Qwen3-4B-q4f16_1-MLC' },
   'qwen3-30b': { contextWindow: 32_768, mlcId: 'Qwen3-30B-A3B-q4f16_1-MLC' },
 };

--- a/tests/providers/webllm.test.ts
+++ b/tests/providers/webllm.test.ts
@@ -39,6 +39,9 @@ describe('WebLLMProvider', () => {
 
   it('returns context limit for known models', () => {
     expect(provider.getContextLimit('qwen3-4b')).toBe(32_768);
+    expect(provider.getContextLimit('qwen3-0.6b')).toBe(32_768);
+    expect(provider.getContextLimit('qwen3-1.7b')).toBe(32_768);
+    expect(provider.getContextLimit('qwen3-30b')).toBe(32_768);
   });
 
   it('returns default limit for unknown models', () => {
@@ -91,6 +94,30 @@ describe('WebLLMProvider', () => {
       expect(response.content).toHaveLength(1);
       expect(response.content[0]).toMatchObject({ type: 'text', text: 'Hello from WebLLM' });
       expect(response.stopReason).toBe('end_turn');
+    });
+
+    it('accepts smaller models (qwen3-0.6b)', async () => {
+      const freshProvider = new WebLLMProvider();
+      const response = await freshProvider.chat({
+        model: 'qwen3-0.6b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      expect(response.content).toBeDefined();
+      expect(response.model).toBe('qwen3-0.6b');
+    });
+
+    it('accepts smaller models (qwen3-1.7b)', async () => {
+      const freshProvider = new WebLLMProvider();
+      const response = await freshProvider.chat({
+        model: 'qwen3-1.7b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      expect(response.content).toBeDefined();
+      expect(response.model).toBe('qwen3-1.7b');
     });
 
     it('parses tool calls from content', async () => {


### PR DESCRIPTION
## Summary
This PR adds support for two smaller Qwen3 models (0.6B and 1.7B) to the WebLLM provider, enabling users to run lighter-weight models locally with lower memory requirements.

## Key Changes
- Added `qwen3-0.6b` and `qwen3-1.7b` model configurations to the WebLLM provider with their respective MLC IDs and 32,768 token context windows
- Updated the settings UI to display the new smaller models with their approximate memory footprints (400 MB and 1 GB respectively)
- Added test coverage for both new models to verify context limit retrieval and chat functionality

## Implementation Details
- Both new models are configured with a 32,768 token context window, matching the existing Qwen3 models
- The MLC IDs follow the standard naming convention: `Qwen3-{size}-q4f16_1-MLC`
- Models are listed in ascending size order in the UI for better user experience
- Integration tests verify that the provider correctly accepts and processes requests for both new models

https://claude.ai/code/session_0163BFCQqrwPjWMgnR4koQjM