### PR TITLE
Add .claude/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .env
 .playwright-mcp
 coverage
+.claude/


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude the `.claude/` directory from version control.

## Changes
- Added `.claude/` to the gitignore patterns to prevent Claude-related configuration or cache files from being committed to the repository

## Details
This change ensures that local Claude tool configurations or temporary files are not tracked by git, keeping the repository clean and avoiding potential conflicts from user-specific Claude settings.

https://claude.ai/code/session_015BS2oojUXp7X72PtR6Us9L