### PR TITLE
Fix Skill Hub: normalize ClawHub API response to match real schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2151,6 +2152,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -7353,6 +7370,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/components/skill-hub/SkillHubPage.tsx
+++ b/src/components/skill-hub/SkillHubPage.tsx
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { useEffect, useRef, useState } from 'react';
-import { Search, Download, X, ExternalLink } from 'lucide-react';
+import { Search, Download, X, ExternalLink, Star } from 'lucide-react';
 import { useSkillHubStore } from '../../stores/skill-hub-store.js';
 import type { HubSkill } from '../../types.js';
 
@@ -28,12 +28,24 @@ function SkillCard({
         <h4 className="card-title text-sm">{skill.name}</h4>
         <p className="text-xs opacity-70 line-clamp-2">{skill.description}</p>
         <div className="flex flex-wrap gap-1.5 mt-1 items-center">
-          <span className="badge badge-sm badge-outline">{skill.author}</span>
-          <span className="badge badge-sm badge-ghost">v{skill.version}</span>
-          <span className="flex items-center gap-0.5 text-xs opacity-50">
-            <Download className="w-3 h-3" />
-            {skill.downloads.toLocaleString()}
-          </span>
+          {skill.author && (
+            <span className="badge badge-sm badge-outline">{skill.author}</span>
+          )}
+          {skill.version && (
+            <span className="badge badge-sm badge-ghost">v{skill.version}</span>
+          )}
+          {skill.downloads > 0 && (
+            <span className="flex items-center gap-0.5 text-xs opacity-50">
+              <Download className="w-3 h-3" />
+              {skill.downloads.toLocaleString()}
+            </span>
+          )}
+          {skill.stars > 0 && (
+            <span className="flex items-center gap-0.5 text-xs opacity-50">
+              <Star className="w-3 h-3" />
+              {skill.stars}
+            </span>
+          )}
         </div>
       </div>
     </div>
@@ -165,18 +177,39 @@ export function SkillHubPage() {
               </div>
             ) : selectedSkill ? (
               <div className="space-y-4">
-                <div>
-                  <h3 className="text-lg font-bold">{selectedSkill.name}</h3>
-                  <p className="text-sm opacity-70">{selectedSkill.description}</p>
+                <div className="flex items-start gap-3">
+                  {selectedSkill.avatarUrl && (
+                    <img
+                      src={selectedSkill.avatarUrl}
+                      alt={selectedSkill.author}
+                      className="w-10 h-10 rounded-full"
+                    />
+                  )}
+                  <div>
+                    <h3 className="text-lg font-bold">{selectedSkill.name}</h3>
+                    <p className="text-sm opacity-70">{selectedSkill.description}</p>
+                  </div>
                 </div>
 
                 <div className="flex flex-wrap gap-2 text-sm">
-                  <span className="badge badge-outline">{selectedSkill.author}</span>
-                  <span className="badge badge-ghost">v{selectedSkill.version}</span>
-                  <span className="flex items-center gap-1 opacity-60">
-                    <Download className="w-3.5 h-3.5" />
-                    {selectedSkill.downloads.toLocaleString()} downloads
-                  </span>
+                  {selectedSkill.author && (
+                    <span className="badge badge-outline">{selectedSkill.author}</span>
+                  )}
+                  {selectedSkill.version && (
+                    <span className="badge badge-ghost">v{selectedSkill.version}</span>
+                  )}
+                  {selectedSkill.downloads > 0 && (
+                    <span className="flex items-center gap-1 opacity-60">
+                      <Download className="w-3.5 h-3.5" />
+                      {selectedSkill.downloads.toLocaleString()} downloads
+                    </span>
+                  )}
+                  {selectedSkill.stars > 0 && (
+                    <span className="flex items-center gap-1 opacity-60">
+                      <Star className="w-3.5 h-3.5" />
+                      {selectedSkill.stars} stars
+                    </span>
+                  )}
                 </div>
 
                 {/* Install command */}
@@ -187,11 +220,12 @@ export function SkillHubPage() {
                   </code>
                 </div>
 
-                {/* SKILL.md content */}
-                {selectedSkill.readme && (
-                  <div className="prose prose-sm max-w-none">
+                {/* Changelog */}
+                {selectedSkill.changelog && (
+                  <div>
+                    <p className="text-xs font-semibold opacity-60 mb-1">Changelog</p>
                     <pre className="whitespace-pre-wrap text-xs bg-base-200 p-4 rounded-lg overflow-auto max-h-96">
-                      {selectedSkill.readme}
+                      {selectedSkill.changelog}
                     </pre>
                   </div>
                 )}

--- a/src/skill-hub.ts
+++ b/src/skill-hub.ts
@@ -1,11 +1,100 @@
 // ---------------------------------------------------------------------------
 // SafeClaw — ClawHub Skill Hub API client
 // ---------------------------------------------------------------------------
+//
+// Wraps the ClawHub public REST API and normalizes the raw responses into
+// clean, UI-friendly types (HubSkill / HubSkillDetail).
 
-import type { HubSkillsResponse, HubSkillDetail, HubSortBy } from './types.js';
+import type { HubSkill, HubSkillsResponse, HubSkillDetail } from './types.js';
 
 /** ClawHub registry API base URL */
 export const CLAWHUB_API_BASE = 'https://clawhub.ai/api/v1';
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (not exported — internal only)
+// ---------------------------------------------------------------------------
+
+interface RawListItem {
+  slug: string;
+  displayName: string;
+  summary: string;
+  tags: Record<string, string>;
+  stats: { downloads: number; stars: number; installsAllTime: number; versions: number; comments: number; installsCurrent: number };
+  createdAt: number;
+  updatedAt: number;
+  latestVersion: { version: string; createdAt: number; changelog: string | null; license: string | null } | null;
+  metadata: unknown;
+}
+
+interface RawListResponse {
+  items: RawListItem[];
+  nextCursor: string | null;
+}
+
+interface RawSearchResult {
+  score: number;
+  slug: string;
+  displayName: string;
+  summary: string;
+  version: string | null;
+  updatedAt: number;
+}
+
+interface RawSearchResponse {
+  results: RawSearchResult[];
+}
+
+interface RawDetailResponse {
+  skill: {
+    slug: string;
+    displayName: string;
+    summary: string;
+    tags: Record<string, string>;
+    stats: { downloads: number; stars: number; installsAllTime: number; versions: number; comments: number; installsCurrent: number };
+    createdAt: number;
+    updatedAt: number;
+  };
+  latestVersion: { version: string; createdAt: number; changelog: string | null; license: string | null } | null;
+  metadata: unknown;
+  owner: { handle: string; displayName: string; image: string } | null;
+  moderation: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Normalizers
+// ---------------------------------------------------------------------------
+
+function normalizeListItem(raw: RawListItem): HubSkill {
+  return {
+    slug: raw.slug,
+    name: raw.displayName || raw.slug,
+    description: raw.summary || '',
+    author: '',
+    version: raw.latestVersion?.version || '',
+    downloads: raw.stats?.downloads ?? 0,
+    stars: raw.stats?.stars ?? 0,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function normalizeSearchResult(raw: RawSearchResult): HubSkill {
+  return {
+    slug: raw.slug,
+    name: raw.displayName || raw.slug,
+    description: raw.summary || '',
+    author: '',
+    version: raw.version || '',
+    downloads: 0,
+    stars: 0,
+    createdAt: 0,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API functions
+// ---------------------------------------------------------------------------
 
 /**
  * Search skills by query using ClawHub's vector search.
@@ -21,19 +110,23 @@ export async function searchSkills(
     headers: { 'Accept': 'application/json' },
   });
   if (!res.ok) throw new Error(`ClawHub API error: ${res.status}`);
-  return res.json();
+
+  const raw: RawSearchResponse = await res.json();
+  return {
+    items: (raw.results || []).map(normalizeSearchResult),
+    nextCursor: null, // search endpoint has no pagination
+  };
 }
 
 /**
- * List skills from the registry with optional sorting and pagination.
+ * List skills from the registry with optional pagination.
  */
 export async function listSkills(options?: {
-  sortBy?: HubSortBy;
+  sortBy?: string;
   limit?: number;
   cursor?: string;
 }): Promise<HubSkillsResponse> {
   const params = new URLSearchParams();
-  if (options?.sortBy) params.set('sortBy', options.sortBy);
   if (options?.limit !== undefined) params.set('limit', String(options.limit));
   if (options?.cursor) params.set('cursor', options.cursor);
 
@@ -44,7 +137,12 @@ export async function listSkills(options?: {
     headers: { 'Accept': 'application/json' },
   });
   if (!res.ok) throw new Error(`ClawHub API error: ${res.status}`);
-  return res.json();
+
+  const raw: RawListResponse = await res.json();
+  return {
+    items: (raw.items || []).map(normalizeListItem),
+    nextCursor: raw.nextCursor || null,
+  };
 }
 
 /**
@@ -55,5 +153,21 @@ export async function getSkillDetail(slug: string): Promise<HubSkillDetail> {
     headers: { 'Accept': 'application/json' },
   });
   if (!res.ok) throw new Error(`ClawHub API error: ${res.status}`);
-  return res.json();
+
+  const raw: RawDetailResponse = await res.json();
+  const s = raw.skill;
+
+  return {
+    slug: s.slug,
+    name: s.displayName || s.slug,
+    description: s.summary || '',
+    author: raw.owner?.handle || '',
+    version: raw.latestVersion?.version || '',
+    downloads: s.stats?.downloads ?? 0,
+    stars: s.stats?.stars ?? 0,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+    changelog: raw.latestVersion?.changelog || '',
+    avatarUrl: raw.owner?.image || '',
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,7 @@ export interface GroupInfo {
 // ClawHub Skill Hub types
 // ---------------------------------------------------------------------------
 
-/** A skill listing from the ClawHub registry */
+/** A normalized skill listing for the UI */
 export interface HubSkill {
   slug: string;
   name: string;
@@ -194,8 +194,9 @@ export interface HubSkill {
   author: string;
   version: string;
   downloads: number;
-  createdAt: string;
-  updatedAt: string;
+  stars: number;
+  createdAt: number;
+  updatedAt: number;
 }
 
 /** Response from the ClawHub skills listing API */
@@ -204,9 +205,15 @@ export interface HubSkillsResponse {
   nextCursor: string | null;
 }
 
-/** Detailed skill info including SKILL.md content */
+/** Detailed skill info with owner and changelog */
 export interface HubSkillDetail extends HubSkill {
-  readme: string;
+  changelog: string;
+  avatarUrl: string;
+}
+
+/** Search result from ClawHub */
+export interface HubSearchResult {
+  items: HubSkill[];
 }
 
 /** Sort options for skill listing */

--- a/tests/components/skill-hub/SkillHubPage.test.tsx
+++ b/tests/components/skill-hub/SkillHubPage.test.tsx
@@ -34,8 +34,9 @@ const mockSkill: HubSkill = {
   author: 'tester',
   version: '1.0.0',
   downloads: 42,
-  createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-03-01T00:00:00Z',
+  stars: 5,
+  createdAt: 1700000000000,
+  updatedAt: 1709000000000,
 };
 
 const mockSkill2: HubSkill = {
@@ -45,8 +46,9 @@ const mockSkill2: HubSkill = {
   author: 'dev',
   version: '2.0.0',
   downloads: 200,
-  createdAt: '2026-02-01T00:00:00Z',
-  updatedAt: '2026-03-05T00:00:00Z',
+  stars: 10,
+  createdAt: 1705000000000,
+  updatedAt: 1709500000000,
 };
 
 describe('SkillHubPage', () => {
@@ -185,12 +187,12 @@ describe('SkillHubPage', () => {
   it('shows skill detail modal when selectedSkill is set', () => {
     useSkillHubStore.setState({
       skills: [mockSkill],
-      selectedSkill: { ...mockSkill, readme: '# Test Skill\n\nDetailed info.' },
+      selectedSkill: { ...mockSkill, changelog: 'Initial release of Test Skill.', avatarUrl: '' },
     });
 
     render(<SkillHubPage />);
     expect(screen.getByTestId('skill-detail-modal')).toBeInTheDocument();
-    expect(screen.getByText(/detailed info/i)).toBeInTheDocument();
+    expect(screen.getByText(/initial release/i)).toBeInTheDocument();
   });
 
   it('shows loading state in detail modal', () => {
@@ -207,7 +209,7 @@ describe('SkillHubPage', () => {
     const clearSelection = vi.fn();
     useSkillHubStore.setState({
       skills: [mockSkill],
-      selectedSkill: { ...mockSkill, readme: '# Test' },
+      selectedSkill: { ...mockSkill, changelog: '', avatarUrl: '' },
       clearSelection,
     });
 

--- a/tests/integration/skill-hub-flow.test.tsx
+++ b/tests/integration/skill-hub-flow.test.tsx
@@ -1,0 +1,258 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { SkillHubPage } from '../../src/components/skill-hub/SkillHubPage';
+import { useSkillHubStore } from '../../src/stores/skill-hub-store';
+
+// Use the REAL store (not mocked) to catch real runtime issues
+// Mock only the fetch to avoid network calls
+
+/** Helper: create a raw ClawHub list API response */
+function rawListResponse(items: Array<{
+  slug: string;
+  displayName: string;
+  summary: string;
+  downloads?: number;
+  stars?: number;
+  version?: string;
+}>, nextCursor: string | null = null) {
+  return {
+    items: items.map((item) => ({
+      slug: item.slug,
+      displayName: item.displayName,
+      summary: item.summary,
+      tags: { latest: item.version || '1.0.0' },
+      stats: {
+        downloads: item.downloads ?? 0,
+        stars: item.stars ?? 0,
+        installsAllTime: 0,
+        installsCurrent: 0,
+        versions: 1,
+        comments: 0,
+      },
+      createdAt: 1700000000000,
+      updatedAt: 1709000000000,
+      latestVersion: { version: item.version || '1.0.0', createdAt: 1700000000000, changelog: null, license: null },
+      metadata: null,
+    })),
+    nextCursor,
+  };
+}
+
+/** Helper: create a raw ClawHub search API response */
+function rawSearchResponse(results: Array<{
+  slug: string;
+  displayName: string;
+  summary: string;
+  version?: string;
+}>) {
+  return {
+    results: results.map((r) => ({
+      score: 3.0,
+      slug: r.slug,
+      displayName: r.displayName,
+      summary: r.summary,
+      version: r.version || '1.0.0',
+      updatedAt: 1709000000000,
+    })),
+  };
+}
+
+/** Helper: create a raw ClawHub detail API response */
+function rawDetailResponse(skill: {
+  slug: string;
+  displayName: string;
+  summary: string;
+  owner?: string;
+  changelog?: string;
+}) {
+  return {
+    skill: {
+      slug: skill.slug,
+      displayName: skill.displayName,
+      summary: skill.summary,
+      tags: { latest: '1.0.0' },
+      stats: { downloads: 100, stars: 5, installsAllTime: 10, installsCurrent: 8, versions: 1, comments: 0 },
+      createdAt: 1700000000000,
+      updatedAt: 1709000000000,
+    },
+    latestVersion: { version: '1.0.0', createdAt: 1700000000000, changelog: skill.changelog || null, license: null },
+    metadata: null,
+    owner: skill.owner ? { handle: skill.owner, displayName: skill.owner, image: '' } : null,
+    moderation: null,
+  };
+}
+
+function mockJsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('SkillHub integration (real store)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Reset store to initial state
+    useSkillHubStore.setState({
+      skills: [],
+      loading: false,
+      error: null,
+      query: '',
+      nextCursor: null,
+      selectedSkill: null,
+      selectedSkillLoading: false,
+    });
+  });
+
+  it('renders and loads skills from ClawHub API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockJsonResponse(rawListResponse([
+        { slug: 'git-helper', displayName: 'Git Helper', summary: 'Helps with git operations' },
+      ])),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/skill-hub']}>
+        <Routes>
+          <Route path="/skill-hub" element={<SkillHubPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Page title should be visible immediately
+    expect(screen.getByText('Skill Hub')).toBeInTheDocument();
+    expect(screen.getByText(/powered by/i)).toBeInTheDocument();
+
+    // Wait for skills to load
+    await waitFor(() => {
+      expect(screen.getByText('Git Helper')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Helps with git operations')).toBeInTheDocument();
+  });
+
+  it('handles CORS/network errors gracefully without crashing', async () => {
+    // Simulate CORS error (fetch throws TypeError for network errors)
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/skill-hub']}>
+        <Routes>
+          <Route path="/skill-hub" element={<SkillHubPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Page should still render
+    expect(screen.getByText('Skill Hub')).toBeInTheDocument();
+
+    // Error should be displayed (not crash the app)
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
+    });
+  });
+
+  it('handles 500 errors gracefully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Server Error', { status: 500 }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/skill-hub']}>
+        <Routes>
+          <Route path="/skill-hub" element={<SkillHubPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/ClawHub API error: 500/)).toBeInTheDocument();
+    });
+  });
+
+  it('can search skills after initial load', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      // First call: browse (list)
+      .mockResolvedValueOnce(
+        mockJsonResponse(rawListResponse([])),
+      )
+      // Second call: search
+      .mockResolvedValueOnce(
+        mockJsonResponse(rawSearchResponse([
+          { slug: 'search-result', displayName: 'Search Result', summary: 'Found by search' },
+        ])),
+      );
+
+    render(
+      <MemoryRouter initialEntries={['/skill-hub']}>
+        <Routes>
+          <Route path="/skill-hub" element={<SkillHubPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Wait for initial load to complete
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Type search query
+    const input = screen.getByPlaceholderText(/search skills/i);
+    await userEvent.type(input, 'search');
+
+    // Wait for debounced search
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    }, { timeout: 1000 });
+
+    await waitFor(() => {
+      expect(screen.getByText('Search Result')).toBeInTheDocument();
+    });
+  });
+
+  it('can select a skill and view its detail', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      // First call: browse (list)
+      .mockResolvedValueOnce(
+        mockJsonResponse(rawListResponse([
+          { slug: 'detail-test', displayName: 'Detail Test', summary: 'Click me for details' },
+        ])),
+      )
+      // Second call: getSkillDetail
+      .mockResolvedValueOnce(
+        mockJsonResponse(rawDetailResponse({
+          slug: 'detail-test',
+          displayName: 'Detail Test',
+          summary: 'Click me for details',
+          owner: 'test-author',
+          changelog: 'Initial release with great features.',
+        })),
+      );
+
+    render(
+      <MemoryRouter initialEntries={['/skill-hub']}>
+        <Routes>
+          <Route path="/skill-hub" element={<SkillHubPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Wait for skill card to appear
+    await waitFor(() => {
+      expect(screen.getByText('Detail Test')).toBeInTheDocument();
+    });
+
+    // Click the skill card
+    await userEvent.click(screen.getByText('Detail Test'));
+
+    // Wait for detail modal
+    await waitFor(() => {
+      expect(screen.getByText(/npx clawhub@latest install detail-test/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Initial release with great features/)).toBeInTheDocument();
+  });
+});

--- a/tests/skill-hub.test.ts
+++ b/tests/skill-hub.test.ts
@@ -5,23 +5,44 @@ import {
   CLAWHUB_API_BASE,
 } from '../src/skill-hub';
 import { mockFetchResponse } from './helpers';
-import type { HubSkill, HubSkillDetail } from '../src/types';
 
 describe('skill-hub', () => {
-  const mockSkill: HubSkill = {
+  // Raw API responses (matching the actual ClawHub API format)
+  const rawListItem = {
     slug: 'test-skill',
-    name: 'Test Skill',
-    description: 'A test skill for unit testing',
-    author: 'tester',
-    version: '1.0.0',
-    downloads: 42,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-03-01T00:00:00Z',
+    displayName: 'Test Skill',
+    summary: 'A test skill for unit testing',
+    tags: { latest: '1.0.0' },
+    stats: { downloads: 42, stars: 5, installsAllTime: 10, installsCurrent: 8, versions: 1, comments: 0 },
+    createdAt: 1700000000000,
+    updatedAt: 1709000000000,
+    latestVersion: { version: '1.0.0', createdAt: 1700000000000, changelog: 'Initial release', license: null },
+    metadata: null,
   };
 
-  const mockDetail: HubSkillDetail = {
-    ...mockSkill,
-    readme: '# Test Skill\n\nThis is a test skill.',
+  const rawSearchResult = {
+    score: 3.5,
+    slug: 'search-skill',
+    displayName: 'Search Skill',
+    summary: 'Found by search',
+    version: '2.0.0',
+    updatedAt: 1709000000000,
+  };
+
+  const rawDetailResponse = {
+    skill: {
+      slug: 'test-skill',
+      displayName: 'Test Skill',
+      summary: 'A test skill for unit testing',
+      tags: { latest: '1.0.0' },
+      stats: { downloads: 42, stars: 5, installsAllTime: 10, installsCurrent: 8, versions: 1, comments: 0 },
+      createdAt: 1700000000000,
+      updatedAt: 1709000000000,
+    },
+    latestVersion: { version: '1.0.0', createdAt: 1700000000000, changelog: 'Initial release', license: null },
+    metadata: null,
+    owner: { handle: 'tester', displayName: 'Tester', image: 'https://example.com/avatar.png' },
+    moderation: null,
   };
 
   beforeEach(() => {
@@ -35,20 +56,23 @@ describe('skill-hub', () => {
   });
 
   describe('searchSkills', () => {
-    it('fetches skills matching a query', async () => {
+    it('fetches and normalizes search results', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse({ items: [mockSkill], nextCursor: null }),
+        mockFetchResponse({ results: [rawSearchResult] }),
       );
 
       const result = await searchSkills('test');
       expect(result.items).toHaveLength(1);
-      expect(result.items[0].slug).toBe('test-skill');
+      expect(result.items[0].slug).toBe('search-skill');
+      expect(result.items[0].name).toBe('Search Skill');
+      expect(result.items[0].description).toBe('Found by search');
+      expect(result.items[0].version).toBe('2.0.0');
       expect(result.nextCursor).toBeNull();
     });
 
     it('encodes the query parameter', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse({ items: [], nextCursor: null }),
+        mockFetchResponse({ results: [] }),
       );
 
       await searchSkills('hello world');
@@ -60,7 +84,7 @@ describe('skill-hub', () => {
 
     it('passes limit parameter', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse({ items: [], nextCursor: null }),
+        mockFetchResponse({ results: [] }),
       );
 
       await searchSkills('test', 5);
@@ -83,25 +107,40 @@ describe('skill-hub', () => {
 
       await expect(searchSkills('test')).rejects.toThrow('Network failure');
     });
+
+    it('handles empty results gracefully', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockFetchResponse({ results: [] }),
+      );
+
+      const result = await searchSkills('nonexistent');
+      expect(result.items).toEqual([]);
+    });
   });
 
   describe('listSkills', () => {
-    it('fetches a paginated list of skills', async () => {
+    it('fetches and normalizes a paginated list of skills', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse({ items: [mockSkill], nextCursor: 'abc123' }),
+        mockFetchResponse({ items: [rawListItem], nextCursor: 'abc123' }),
       );
 
       const result = await listSkills();
       expect(result.items).toHaveLength(1);
+      expect(result.items[0].slug).toBe('test-skill');
+      expect(result.items[0].name).toBe('Test Skill');
+      expect(result.items[0].description).toBe('A test skill for unit testing');
+      expect(result.items[0].version).toBe('1.0.0');
+      expect(result.items[0].downloads).toBe(42);
+      expect(result.items[0].stars).toBe(5);
       expect(result.nextCursor).toBe('abc123');
     });
 
-    it('passes sort and limit parameters', async () => {
+    it('passes limit parameter', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         mockFetchResponse({ items: [], nextCursor: null }),
       );
 
-      await listSkills({ sortBy: 'downloads', limit: 10 });
+      await listSkills({ limit: 10 });
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('limit=10');
     });
@@ -126,19 +165,24 @@ describe('skill-hub', () => {
   });
 
   describe('getSkillDetail', () => {
-    it('fetches detail for a specific skill by slug', async () => {
+    it('fetches and normalizes detail for a specific skill', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse(mockDetail),
+        mockFetchResponse(rawDetailResponse),
       );
 
       const result = await getSkillDetail('test-skill');
       expect(result.slug).toBe('test-skill');
-      expect(result.readme).toContain('# Test Skill');
+      expect(result.name).toBe('Test Skill');
+      expect(result.author).toBe('tester');
+      expect(result.changelog).toBe('Initial release');
+      expect(result.avatarUrl).toBe('https://example.com/avatar.png');
+      expect(result.downloads).toBe(42);
+      expect(result.stars).toBe(5);
     });
 
     it('includes the slug in the URL path', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        mockFetchResponse(mockDetail),
+        mockFetchResponse(rawDetailResponse),
       );
 
       await getSkillDetail('my-cool-skill');
@@ -160,6 +204,26 @@ describe('skill-hub', () => {
       vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Timeout'));
 
       await expect(getSkillDetail('test')).rejects.toThrow('Timeout');
+    });
+
+    it('handles missing owner gracefully', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockFetchResponse({ ...rawDetailResponse, owner: null }),
+      );
+
+      const result = await getSkillDetail('test-skill');
+      expect(result.author).toBe('');
+      expect(result.avatarUrl).toBe('');
+    });
+
+    it('handles missing latestVersion gracefully', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockFetchResponse({ ...rawDetailResponse, latestVersion: null }),
+      );
+
+      const result = await getSkillDetail('test-skill');
+      expect(result.version).toBe('');
+      expect(result.changelog).toBe('');
     });
   });
 });

--- a/tests/stores/skill-hub-store.test.ts
+++ b/tests/stores/skill-hub-store.test.ts
@@ -17,8 +17,9 @@ const mockSkill: HubSkill = {
   author: 'tester',
   version: '1.0.0',
   downloads: 100,
-  createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-03-01T00:00:00Z',
+  stars: 5,
+  createdAt: 1700000000000,
+  updatedAt: 1709000000000,
 };
 
 const mockSkill2: HubSkill = {
@@ -28,8 +29,9 @@ const mockSkill2: HubSkill = {
   author: 'dev',
   version: '2.0.0',
   downloads: 200,
-  createdAt: '2026-02-01T00:00:00Z',
-  updatedAt: '2026-03-05T00:00:00Z',
+  stars: 10,
+  createdAt: 1705000000000,
+  updatedAt: 1709500000000,
 };
 
 describe('useSkillHubStore', () => {
@@ -193,7 +195,7 @@ describe('useSkillHubStore', () => {
 
   describe('selectSkill', () => {
     it('fetches skill detail and sets selectedSkill', async () => {
-      const detail = { ...mockSkill, readme: '# Test' };
+      const detail = { ...mockSkill, changelog: 'Initial release', avatarUrl: 'https://example.com/avatar.png' };
       vi.mocked(getSkillDetail).mockResolvedValueOnce(detail);
 
       await useSkillHubStore.getState().selectSkill('test-skill');
@@ -212,7 +214,7 @@ describe('useSkillHubStore', () => {
       const promise = useSkillHubStore.getState().selectSkill('test-skill');
       expect(useSkillHubStore.getState().selectedSkillLoading).toBe(true);
 
-      resolvePromise!({ ...mockSkill, readme: '# Test' });
+      resolvePromise!({ ...mockSkill, changelog: '', avatarUrl: '' });
       await promise;
       expect(useSkillHubStore.getState().selectedSkillLoading).toBe(false);
     });
@@ -230,7 +232,7 @@ describe('useSkillHubStore', () => {
   describe('clearSelection', () => {
     it('clears selectedSkill', () => {
       useSkillHubStore.setState({
-        selectedSkill: { ...mockSkill, readme: '# Test' },
+        selectedSkill: { ...mockSkill, changelog: '', avatarUrl: '' },
       });
 
       useSkillHubStore.getState().clearSelection();


### PR DESCRIPTION
The SkillHubPage was not loading because the HubSkill types didn't match the actual ClawHub API response format. The API returns displayName (not name), summary (not description), nested stats object (not flat downloads), and epoch-ms timestamps (not ISO strings).

Root cause: calling toLocaleString() on undefined stats.downloads crashed the SkillCard component, and undefined displayName caused blank cards.

Fix: Added normalization layer in skill-hub.ts that transforms raw API responses (list, search, detail) into clean HubSkill types. Updated types to match reality (stars, epoch timestamps, changelog instead of readme, avatarUrl). Added integration tests that use the real store with mocked fetch to catch schema mismatches.

Also installed @playwright/test (browsers couldn't be downloaded in this environment, but the package is available for future e2e tests).

https://claude.ai/code/session_01RGyMvJE6ucWhjsKEEq6Rgr