### PR TITLE
Sort skills by downloads descending, alphabetically for ties

### DIFF
--- a/src/skill-hub.ts
+++ b/src/skill-hub.ts
@@ -93,6 +93,21 @@ function normalizeSearchResult(raw: RawSearchResult): HubSkill {
 }
 
 // ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/**
+ * Sort skills by downloads descending; ties broken alphabetically by name.
+ * Returns a new array — does not mutate the input.
+ */
+export function sortSkills<T extends HubSkill>(skills: T[]): T[] {
+  return [...skills].sort((a, b) => {
+    if (b.downloads !== a.downloads) return b.downloads - a.downloads;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Public API functions
 // ---------------------------------------------------------------------------
 

--- a/src/stores/skill-hub-store.ts
+++ b/src/stores/skill-hub-store.ts
@@ -4,7 +4,7 @@
 
 import { create } from 'zustand';
 import type { HubSkill, HubSkillDetail } from '../types.js';
-import { searchSkills, listSkills, getSkillDetail } from '../skill-hub.js';
+import { searchSkills, listSkills, getSkillDetail, sortSkills } from '../skill-hub.js';
 
 interface SkillHubStoreState {
   skills: HubSkill[];
@@ -36,7 +36,7 @@ export const useSkillHubStore = create<SkillHubStoreState>((set, get) => ({
     set({ loading: true, error: null, query: '' });
     try {
       const result = await listSkills({ limit: 20 });
-      set({ skills: result.items, nextCursor: result.nextCursor, loading: false });
+      set({ skills: sortSkills(result.items), nextCursor: result.nextCursor, loading: false });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err), loading: false });
     }
@@ -46,7 +46,7 @@ export const useSkillHubStore = create<SkillHubStoreState>((set, get) => ({
     set({ loading: true, error: null, query });
     try {
       const result = await searchSkills(query, limit);
-      set({ skills: result.items, nextCursor: result.nextCursor, loading: false });
+      set({ skills: sortSkills(result.items), nextCursor: result.nextCursor, loading: false });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err), loading: false });
     }
@@ -62,7 +62,7 @@ export const useSkillHubStore = create<SkillHubStoreState>((set, get) => ({
         ? await searchSkills(query)
         : await listSkills({ cursor: nextCursor, limit: 20 });
       set({
-        skills: [...skills, ...result.items],
+        skills: sortSkills([...skills, ...result.items]),
         nextCursor: result.nextCursor,
         loading: false,
       });

--- a/tests/skill-hub.test.ts
+++ b/tests/skill-hub.test.ts
@@ -2,8 +2,10 @@ import {
   searchSkills,
   listSkills,
   getSkillDetail,
+  sortSkills,
   CLAWHUB_API_BASE,
 } from '../src/skill-hub';
+import type { HubSkill } from '../src/types';
 import { mockFetchResponse } from './helpers';
 
 describe('skill-hub', () => {
@@ -224,6 +226,80 @@ describe('skill-hub', () => {
       const result = await getSkillDetail('test-skill');
       expect(result.version).toBe('');
       expect(result.changelog).toBe('');
+    });
+  });
+
+  describe('sortSkills', () => {
+    const makeSkill = (name: string, downloads: number): HubSkill => ({
+      slug: name.toLowerCase().replace(/\s+/g, '-'),
+      name,
+      description: '',
+      author: '',
+      version: '1.0.0',
+      downloads,
+      stars: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    it('sorts skills by downloads descending', () => {
+      const skills = [
+        makeSkill('Low', 10),
+        makeSkill('High', 500),
+        makeSkill('Medium', 100),
+      ];
+      const sorted = sortSkills(skills);
+      expect(sorted.map(s => s.name)).toEqual(['High', 'Medium', 'Low']);
+    });
+
+    it('sorts alphabetically by name when downloads are equal', () => {
+      const skills = [
+        makeSkill('Zebra', 50),
+        makeSkill('Alpha', 50),
+        makeSkill('Mango', 50),
+      ];
+      const sorted = sortSkills(skills);
+      expect(sorted.map(s => s.name)).toEqual(['Alpha', 'Mango', 'Zebra']);
+    });
+
+    it('uses alphabetical tiebreaker only for equal downloads', () => {
+      const skills = [
+        makeSkill('Zebra', 100),
+        makeSkill('Alpha', 50),
+        makeSkill('Beta', 100),
+        makeSkill('Gamma', 50),
+      ];
+      const sorted = sortSkills(skills);
+      expect(sorted.map(s => s.name)).toEqual(['Beta', 'Zebra', 'Alpha', 'Gamma']);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(sortSkills([])).toEqual([]);
+    });
+
+    it('returns single-item array unchanged', () => {
+      const skills = [makeSkill('Only', 42)];
+      const sorted = sortSkills(skills);
+      expect(sorted).toHaveLength(1);
+      expect(sorted[0].name).toBe('Only');
+    });
+
+    it('does not mutate the original array', () => {
+      const skills = [makeSkill('B', 10), makeSkill('A', 20)];
+      const original = [...skills];
+      sortSkills(skills);
+      expect(skills[0].name).toBe(original[0].name);
+      expect(skills[1].name).toBe(original[1].name);
+    });
+
+    it('is case-insensitive for alphabetical sorting', () => {
+      const skills = [
+        makeSkill('banana', 50),
+        makeSkill('Apple', 50),
+        makeSkill('cherry', 50),
+      ];
+      const sorted = sortSkills(skills);
+      expect(sorted.map(s => s.name)).toEqual(['Apple', 'banana', 'cherry']);
     });
   });
 });

--- a/tests/stores/skill-hub-store.test.ts
+++ b/tests/stores/skill-hub-store.test.ts
@@ -1,12 +1,16 @@
 import { useSkillHubStore } from '../../src/stores/skill-hub-store';
 import type { HubSkill } from '../../src/types';
 
-// Mock the skill-hub API module
-vi.mock('../../src/skill-hub', () => ({
-  searchSkills: vi.fn(),
-  listSkills: vi.fn(),
-  getSkillDetail: vi.fn(),
-}));
+// Mock the skill-hub API module but keep the real sortSkills
+vi.mock('../../src/skill-hub', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/skill-hub')>();
+  return {
+    ...actual,
+    searchSkills: vi.fn(),
+    listSkills: vi.fn(),
+    getSkillDetail: vi.fn(),
+  };
+});
 
 import { searchSkills, listSkills, getSkillDetail } from '../../src/skill-hub';
 
@@ -70,7 +74,9 @@ describe('useSkillHubStore', () => {
 
       const state = useSkillHubStore.getState();
       expect(state.skills).toHaveLength(2);
-      expect(state.skills[0].slug).toBe('test-skill');
+      // Skills are sorted by downloads descending; mockSkill2 has 200 > mockSkill's 100
+      expect(state.skills[0].slug).toBe('another-skill');
+      expect(state.skills[1].slug).toBe('test-skill');
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
       expect(state.query).toBe('');
@@ -164,6 +170,9 @@ describe('useSkillHubStore', () => {
 
       const state = useSkillHubStore.getState();
       expect(state.skills).toHaveLength(2);
+      // Sorted by downloads: mockSkill2 (200) > mockSkill (100)
+      expect(state.skills[0].slug).toBe('another-skill');
+      expect(state.skills[1].slug).toBe('test-skill');
       expect(state.nextCursor).toBeNull();
       expect(listSkills).toHaveBeenCalledWith(expect.objectContaining({ cursor: 'cursor-1' }));
     });
@@ -237,6 +246,57 @@ describe('useSkillHubStore', () => {
 
       useSkillHubStore.getState().clearSelection();
       expect(useSkillHubStore.getState().selectedSkill).toBeNull();
+    });
+  });
+
+  describe('sorting', () => {
+    it('browse returns skills sorted by downloads descending, then alphabetically', async () => {
+      const skillA: HubSkill = { ...mockSkill, slug: 'alpha', name: 'Alpha', downloads: 50 };
+      const skillB: HubSkill = { ...mockSkill, slug: 'beta', name: 'Beta', downloads: 50 };
+      const skillC: HubSkill = { ...mockSkill, slug: 'top', name: 'Top', downloads: 500 };
+
+      vi.mocked(listSkills).mockResolvedValueOnce({
+        items: [skillB, skillC, skillA],
+        nextCursor: null,
+      });
+
+      await useSkillHubStore.getState().browse();
+
+      const names = useSkillHubStore.getState().skills.map(s => s.name);
+      expect(names).toEqual(['Top', 'Alpha', 'Beta']);
+    });
+
+    it('search returns skills sorted by downloads descending, then alphabetically', async () => {
+      const skillX: HubSkill = { ...mockSkill, slug: 'x', name: 'X-Ray', downloads: 10 };
+      const skillY: HubSkill = { ...mockSkill, slug: 'y', name: 'Yankee', downloads: 10 };
+
+      vi.mocked(searchSkills).mockResolvedValueOnce({
+        items: [skillY, skillX],
+        nextCursor: null,
+      });
+
+      await useSkillHubStore.getState().search('test');
+
+      const names = useSkillHubStore.getState().skills.map(s => s.name);
+      expect(names).toEqual(['X-Ray', 'Yankee']);
+    });
+
+    it('loadMore re-sorts the full merged list', async () => {
+      // Initial skill has fewer downloads than the one loaded later
+      const initial: HubSkill = { ...mockSkill, slug: 'low', name: 'Low', downloads: 5 };
+      const loaded: HubSkill = { ...mockSkill, slug: 'high', name: 'High', downloads: 999 };
+
+      useSkillHubStore.setState({ skills: [initial], nextCursor: 'c1', query: '' });
+
+      vi.mocked(listSkills).mockResolvedValueOnce({
+        items: [loaded],
+        nextCursor: null,
+      });
+
+      await useSkillHubStore.getState().loadMore();
+
+      const names = useSkillHubStore.getState().skills.map(s => s.name);
+      expect(names).toEqual(['High', 'Low']);
     });
   });
 


### PR DESCRIPTION
Skills are now sorted from most to least downloaded in browse,
search, and loadMore. When download counts are equal, skills
are ordered alphabetically by name (case-insensitive).

Closes #54

https://claude.ai/code/session_01XdPXWhJAjpVktR9Yeed9aS