### PR TITLE
Redesign settings page with semantic grouping and display model in messages

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -20,6 +20,13 @@ test.describe('Settings page', () => {
     await expect(page.locator('.card-title', { hasText: 'Storage' })).toBeVisible();
   });
 
+  test('renders semantic group headings', async ({ page }) => {
+    await expect(page.locator('text=AI & Models')).toBeVisible();
+    await expect(page.locator('text=Personalization')).toBeVisible();
+    await expect(page.locator('text=Integrations')).toBeVisible();
+    await expect(page.locator('text=Storage & System')).toBeVisible();
+  });
+
   test('theme selector has system/light/dark options', async ({ page }) => {
     const themeSelect = page.locator('select').filter({ hasText: 'System' }).first();
     await expect(themeSelect).toBeVisible();
@@ -82,5 +89,10 @@ test.describe('Settings page', () => {
     await nameInput.clear();
     await nameInput.fill('TestBot');
     await expect(nameInput).toHaveValue('TestBot');
+  });
+
+  test('storage section shows breakdown labels', async ({ page }) => {
+    await expect(page.locator('text=Model weights')).toBeVisible();
+    await expect(page.locator('text=Other data')).toBeVisible();
   });
 });

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -51,6 +51,26 @@ const sanitizeSchema = {
   },
 };
 
+/** Map model IDs to short display labels */
+const MODEL_LABELS: Record<string, string> = {
+  'claude-opus-4-6': 'Opus 4.6',
+  'claude-sonnet-4-6': 'Sonnet 4.6',
+  'claude-haiku-4-5-20251001': 'Haiku 4.5',
+  'gemini-2.5-pro-preview-06-05': 'Gemini 2.5 Pro',
+  'gemini-2.0-flash': 'Gemini 2.0 Flash',
+  'gemini-2.0-flash-lite': 'Gemini Flash Lite',
+  'qwen3-0.6b': 'Qwen3 0.6B',
+  'qwen3-1.7b': 'Qwen3 1.7B',
+  'qwen3-4b': 'Qwen3 4B',
+  'qwen3-30b': 'Qwen3 30B',
+  'gemini-nano': 'Gemini Nano',
+};
+
+function getModelLabel(model?: string): string | null {
+  if (!model) return null;
+  return MODEL_LABELS[model] ?? model;
+}
+
 interface Props {
   message: StoredMessage;
 }
@@ -74,6 +94,11 @@ export function MessageBubble({ message }: Props) {
           isAssistant ? '' : 'chat-bubble-primary'
         }`}
       >
+        {isAssistant && message.model && (
+          <div className="chat-footer opacity-40 text-xs mt-0.5">
+            {getModelLabel(message.model)}
+          </div>
+        )}
         {isAssistant ? (
           <div className="chat-markdown">
             <ReactMarkdown

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,15 +1,20 @@
 // ---------------------------------------------------------------------------
-// SafeClaw — Settings page
+// SafeClaw — Settings page (redesigned with semantic grouping)
 // ---------------------------------------------------------------------------
 
 import { useEffect, useState } from 'react';
 import {
   Palette, KeyRound, Eye, EyeOff, Bot, MessageSquare,
-  Smartphone, HardDrive, Lock, Check, Cpu, Wifi, WifiOff, Download,
+  Smartphone, HardDrive, Lock, Check, Cpu, Wifi, WifiOff, Download, Trash2,
 } from 'lucide-react';
 import { getConfig } from '../../db.js';
 import { CONFIG_KEYS } from '../../config.js';
-import { getStorageEstimate, requestPersistentStorage } from '../../storage.js';
+import {
+  getStorageEstimate,
+  requestPersistentStorage,
+  getModelCacheEstimate,
+  deleteModelCaches,
+} from '../../storage.js';
 import { decryptValue } from '../../crypto.js';
 import { getOrchestrator, useOrchestratorStore } from '../../stores/orchestrator-store.js';
 import { useThemeStore, type ThemeChoice } from '../../stores/theme-store.js';
@@ -116,6 +121,8 @@ export function SettingsPage() {
   const [storageUsage, setStorageUsage] = useState(0);
   const [storageQuota, setStorageQuota] = useState(0);
   const [isPersistent, setIsPersistent] = useState(false);
+  const [modelCacheSize, setModelCacheSize] = useState(0);
+  const [deletingCache, setDeletingCache] = useState(false);
 
   // Theme
   const { theme, setTheme } = useThemeStore();
@@ -153,6 +160,10 @@ export function SettingsPage() {
       if (navigator.storage?.persisted) {
         setIsPersistent(await navigator.storage.persisted());
       }
+
+      // Model cache size
+      const cacheSize = await getModelCacheEstimate();
+      setModelCacheSize(cacheSize);
 
       // Hardware checks
       setHasWebGPU('gpu' in navigator);
@@ -228,328 +239,408 @@ export function SettingsPage() {
     setIsPersistent(granted);
   }
 
+  async function handleDeleteModelCache() {
+    setDeletingCache(true);
+    await deleteModelCaches();
+    setModelCacheSize(0);
+    // Refresh total storage estimate
+    const est = await getStorageEstimate();
+    setStorageUsage(est.usage);
+    setStorageQuota(est.quota);
+    setDeletingCache(false);
+  }
+
   const storagePercent = storageQuota > 0 ? (storageUsage / storageQuota) * 100 : 0;
+  const otherStorage = Math.max(0, storageUsage - modelCacheSize);
 
   return (
-    <div className="h-full overflow-y-auto p-4 sm:p-6 max-w-3xl mx-auto space-y-4">
+    <div className="h-full overflow-y-auto p-4 sm:p-6 max-w-3xl mx-auto space-y-6">
       <h2 className="text-xl font-bold mb-4">Settings</h2>
 
-      {/* ---- Theme ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><Palette className="w-4 h-4" /> Appearance</h3>
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Theme</legend>
-            <select
-              className="select select-bordered select-sm w-full"
-              value={theme}
-              onChange={(e) => setTheme(e.target.value as ThemeChoice)}
-            >
-              <option value="system">System</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </fieldset>
-        </div>
-      </div>
+      {/* ================================================================ */}
+      {/* AI & Models                                                      */}
+      {/* ================================================================ */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider opacity-50 mb-2">AI & Models</h3>
+        <div className="space-y-4">
 
-      {/* ---- Provider Selection ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><Bot className="w-4 h-4" /> LLM Provider</h3>
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Active Provider</legend>
-            <select
-              className="select select-bordered select-sm w-full"
-              value={providerId}
-              onChange={(e) => handleProviderChange(e.target.value as ProviderId)}
-            >
-              {PROVIDERS.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.label}{p.isLocal ? ' (Local)' : ''}
-                </option>
-              ))}
-            </select>
-          </fieldset>
+          {/* ---- Provider & Model Selection ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><Bot className="w-4 h-4" /> LLM Provider</h3>
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Active Provider</legend>
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={providerId}
+                  onChange={(e) => handleProviderChange(e.target.value as ProviderId)}
+                >
+                  {PROVIDERS.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label}{p.isLocal ? ' (Local)' : ''}
+                    </option>
+                  ))}
+                </select>
+              </fieldset>
 
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Model</legend>
-            <select
-              className="select select-bordered select-sm w-full"
-              value={model}
-              onChange={(e) => handleModelChange(e.target.value)}
-            >
-              {availableModels.map((m) => (
-                <option key={m.value} value={m.value}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
-          </fieldset>
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Model</legend>
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={model}
+                  onChange={(e) => handleModelChange(e.target.value)}
+                >
+                  {availableModels.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </fieldset>
 
-          <p className="text-xs opacity-50">
-            Quality-first routing: cloud models by default, local fallback when offline or rate-limited.
-          </p>
-        </div>
-      </div>
-
-      {/* ---- API Keys ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><KeyRound className="w-4 h-4" /> API Keys</h3>
-
-          {/* Anthropic */}
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Anthropic API Key</legend>
-            <div className="flex gap-2">
-              <input
-                type={anthropicKeyMasked ? 'password' : 'text'}
-                className="input input-bordered input-sm w-full flex-1 font-mono"
-                placeholder="sk-ant-..."
-                value={anthropicKey}
-                onChange={(e) => setAnthropicKey(e.target.value)}
-              />
-              <button
-                className="btn btn-ghost btn-sm"
-                onClick={() => setAnthropicKeyMasked(!anthropicKeyMasked)}
-              >
-                {anthropicKeyMasked ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-              </button>
+              <p className="text-xs opacity-50">
+                Quality-first routing: cloud models by default, local fallback when offline or rate-limited.
+              </p>
             </div>
-            <div className="flex items-center gap-2 mt-1">
-              <button
-                className="btn btn-primary btn-sm"
-                onClick={handleSaveAnthropicKey}
-                disabled={!anthropicKey.trim()}
-              >
-                Save
-              </button>
-              {anthropicKeySaved && (
-                <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
+          </div>
+
+          {/* ---- API Keys ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><KeyRound className="w-4 h-4" /> API Keys</h3>
+
+              {/* Anthropic */}
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Anthropic API Key</legend>
+                <div className="flex gap-2">
+                  <input
+                    type={anthropicKeyMasked ? 'password' : 'text'}
+                    className="input input-bordered input-sm w-full flex-1 font-mono"
+                    placeholder="sk-ant-..."
+                    value={anthropicKey}
+                    onChange={(e) => setAnthropicKey(e.target.value)}
+                  />
+                  <button
+                    className="btn btn-ghost btn-sm"
+                    onClick={() => setAnthropicKeyMasked(!anthropicKeyMasked)}
+                  >
+                    {anthropicKeyMasked ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                  </button>
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <button
+                    className="btn btn-primary btn-sm"
+                    onClick={handleSaveAnthropicKey}
+                    disabled={!anthropicKey.trim()}
+                  >
+                    Save
+                  </button>
+                  {anthropicKeySaved && (
+                    <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
+                  )}
+                </div>
+              </fieldset>
+
+              {/* Gemini */}
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Google Gemini API Key</legend>
+                <div className="flex gap-2">
+                  <input
+                    type={geminiKeyMasked ? 'password' : 'text'}
+                    className="input input-bordered input-sm w-full flex-1 font-mono"
+                    placeholder="AIza..."
+                    value={geminiKey}
+                    onChange={(e) => setGeminiKey(e.target.value)}
+                  />
+                  <button
+                    className="btn btn-ghost btn-sm"
+                    onClick={() => setGeminiKeyMasked(!geminiKeyMasked)}
+                  >
+                    {geminiKeyMasked ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                  </button>
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <button
+                    className="btn btn-primary btn-sm"
+                    onClick={handleSaveGeminiKey}
+                    disabled={!geminiKey.trim()}
+                  >
+                    Save
+                  </button>
+                  {geminiKeySaved && (
+                    <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
+                  )}
+                </div>
+              </fieldset>
+
+              <p className="text-xs opacity-50">
+                API keys are encrypted and stored locally. They never leave your browser except to call the respective APIs.
+              </p>
+            </div>
+          </div>
+
+          {/* ---- Local Models ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><Cpu className="w-4 h-4" /> Local Models</h3>
+
+              {/* Hardware compatibility */}
+              <div className="flex flex-wrap gap-2">
+                <div className={`badge badge-sm gap-1.5 ${hasWebGPU ? 'badge-success' : 'badge-error'}`}>
+                  {hasWebGPU ? 'WebGPU available' : 'WebGPU not available'}
+                </div>
+                {deviceMemory !== null && (
+                  <div className={`badge badge-sm gap-1.5 ${deviceMemory >= 4 ? 'badge-success' : 'badge-warning'}`}>
+                    {deviceMemory} GB device memory
+                  </div>
+                )}
+                <div className={`badge badge-sm gap-1.5 ${hasChromeAI ? 'badge-success' : 'badge-ghost'}`}>
+                  {hasChromeAI ? 'Chrome AI ready' : 'Chrome AI not available'}
+                </div>
+              </div>
+
+              {/* Local preference */}
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Local Model Preference</legend>
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={localPref}
+                  onChange={(e) => handleLocalPrefChange(e.target.value as LocalPreference)}
+                >
+                  <option value="off">Off — cloud only</option>
+                  <option value="offline-only">Offline fallback — use local when no internet</option>
+                  <option value="always">Always local — prefer local models</option>
+                </select>
+              </fieldset>
+
+              {/* Download / preload button for local providers */}
+              {currentProvider.isLocal && currentProvider.id === 'webllm' && !webllmProgress && (
+                <button
+                  className="btn btn-outline btn-sm gap-2"
+                  onClick={() => orch.preloadModel()}
+                >
+                  <Download className="w-4 h-4" /> Download Model
+                </button>
+              )}
+
+              {/* Download progress bar */}
+              {webllmProgress && (
+                <div>
+                  <div className="flex items-center gap-2 text-sm">
+                    <Download className="w-4 h-4 animate-pulse" />
+                    <span className="flex-1 truncate">{webllmProgress.status}</span>
+                    <span className="text-xs opacity-60">{Math.round(webllmProgress.progress * 100)}%</span>
+                  </div>
+                  <progress
+                    role="progressbar"
+                    className="progress progress-primary w-full h-2 mt-1"
+                    value={webllmProgress.progress * 100}
+                    max={100}
+                  />
+                </div>
+              )}
+
+              <div className="flex items-center gap-2 text-xs opacity-60">
+                {navigator.onLine
+                  ? <><Wifi className="w-3 h-3" /> Online</>
+                  : <><WifiOff className="w-3 h-3" /> Offline — local models will be used</>
+                }
+              </div>
+
+              {!hasWebGPU && (
+                <p className="text-xs text-warning">
+                  WebGPU is required for WebLLM local models. Use Chrome 113+ with WebGPU enabled.
+                </p>
+              )}
+              {deviceMemory !== null && deviceMemory < 4 && (
+                <p className="text-xs text-warning">
+                  Less than 4 GB device memory detected. Local models may not run reliably.
+                </p>
               )}
             </div>
-          </fieldset>
+          </div>
+        </div>
+      </section>
 
-          {/* Gemini */}
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Google Gemini API Key</legend>
-            <div className="flex gap-2">
-              <input
-                type={geminiKeyMasked ? 'password' : 'text'}
-                className="input input-bordered input-sm w-full flex-1 font-mono"
-                placeholder="AIza..."
-                value={geminiKey}
-                onChange={(e) => setGeminiKey(e.target.value)}
-              />
-              <button
-                className="btn btn-ghost btn-sm"
-                onClick={() => setGeminiKeyMasked(!geminiKeyMasked)}
-              >
-                {geminiKeyMasked ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-              </button>
+      {/* ================================================================ */}
+      {/* Personalization                                                   */}
+      {/* ================================================================ */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider opacity-50 mb-2">Personalization</h3>
+        <div className="space-y-4">
+
+          {/* ---- Theme ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><Palette className="w-4 h-4" /> Appearance</h3>
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Theme</legend>
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={theme}
+                  onChange={(e) => setTheme(e.target.value as ThemeChoice)}
+                >
+                  <option value="system">System</option>
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </fieldset>
             </div>
-            <div className="flex items-center gap-2 mt-1">
-              <button
-                className="btn btn-primary btn-sm"
-                onClick={handleSaveGeminiKey}
-                disabled={!geminiKey.trim()}
-              >
-                Save
-              </button>
-              {geminiKeySaved && (
-                <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
+          </div>
+
+          {/* ---- Assistant Name ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><MessageSquare className="w-4 h-4" /> Assistant Name</h3>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  className="input input-bordered input-sm flex-1"
+                  placeholder="Andy"
+                  value={assistantName}
+                  onChange={(e) => setAssistantName(e.target.value)}
+                  onBlur={handleNameSave}
+                />
+              </div>
+              <p className="text-xs opacity-50">
+                The name used for the assistant. Mention @{assistantName} to trigger a response.
+              </p>
+            </div>
+          </div>
+
+          {/* ---- Profile ---- */}
+          <ProfileSection />
+        </div>
+      </section>
+
+      {/* ================================================================ */}
+      {/* Integrations                                                      */}
+      {/* ================================================================ */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider opacity-50 mb-2">Integrations</h3>
+        <div className="space-y-4">
+
+          {/* ---- Telegram ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><Smartphone className="w-4 h-4" /> Telegram Bot</h3>
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Bot Token</legend>
+                <input
+                  type="password"
+                  className="input input-bordered input-sm w-full font-mono"
+                  placeholder="123456:ABC-DEF..."
+                  value={telegramToken}
+                  onChange={(e) => setTelegramToken(e.target.value)}
+                />
+              </fieldset>
+              <fieldset className="fieldset">
+                <legend className="fieldset-legend">Allowed Chat IDs</legend>
+                <input
+                  type="text"
+                  className="input input-bordered input-sm w-full font-mono"
+                  placeholder="-100123456, 789012"
+                  value={telegramChatIds}
+                  onChange={(e) => setTelegramChatIds(e.target.value)}
+                />
+                <p className="fieldset-label opacity-60">Comma-separated chat IDs</p>
+              </fieldset>
+              <div className="flex items-center gap-2">
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={handleTelegramSave}
+                  disabled={!telegramToken.trim()}
+                >
+                  Save Telegram Config
+                </button>
+                {telegramSaved && (
+                  <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ================================================================ */}
+      {/* Storage & System                                                  */}
+      {/* ================================================================ */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider opacity-50 mb-2">Storage & System</h3>
+        <div className="space-y-4">
+
+          {/* ---- Storage ---- */}
+          <div className="card card-bordered bg-base-200">
+            <div className="card-body p-4 sm:p-6 gap-3">
+              <h3 className="card-title text-base gap-2"><HardDrive className="w-4 h-4" /> Storage</h3>
+
+              {/* Overall usage */}
+              <div>
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span>{formatBytes(storageUsage)} used</span>
+                  <span className="opacity-60">
+                    of {formatBytes(storageQuota)}
+                  </span>
+                </div>
+                <progress
+                  className="progress progress-primary w-full h-2"
+                  value={storagePercent}
+                  max={100}
+                />
+              </div>
+
+              {/* Storage breakdown */}
+              <div className="text-xs space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="opacity-70">Model weights</span>
+                  <span className="font-mono">{formatBytes(modelCacheSize)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="opacity-70">Other data</span>
+                  <span className="font-mono">{formatBytes(otherStorage)}</span>
+                </div>
+              </div>
+
+              {/* Delete model weights */}
+              {modelCacheSize > 0 && (
+                <button
+                  className="btn btn-outline btn-error btn-sm gap-2"
+                  onClick={handleDeleteModelCache}
+                  disabled={deletingCache}
+                >
+                  <Trash2 className="w-4 h-4" />
+                  {deletingCache ? 'Deleting...' : 'Delete Model Weights'}
+                </button>
+              )}
+              {modelCacheSize > 0 && (
+                <p className="text-xs opacity-50">
+                  Models will be re-downloaded automatically on next use.
+                </p>
+              )}
+
+              {!isPersistent && (
+                <button
+                  className="btn btn-outline btn-sm"
+                  onClick={handleRequestPersistent}
+                >
+                  <Lock className="w-4 h-4" /> Request Persistent Storage
+                </button>
+              )}
+              {isPersistent && (
+                <div className="badge badge-success badge-sm gap-1.5">
+                  <Lock className="w-3 h-3" /> Persistent storage active
+                </div>
               )}
             </div>
-          </fieldset>
-
-          <p className="text-xs opacity-50">
-            API keys are encrypted and stored locally. They never leave your browser except to call the respective APIs.
-          </p>
-        </div>
-      </div>
-
-      {/* ---- Local Models ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><Cpu className="w-4 h-4" /> Local Models</h3>
-
-          {/* Hardware compatibility */}
-          <div className="flex flex-wrap gap-2">
-            <div className={`badge badge-sm gap-1.5 ${hasWebGPU ? 'badge-success' : 'badge-error'}`}>
-              {hasWebGPU ? 'WebGPU available' : 'WebGPU not available'}
-            </div>
-            {deviceMemory !== null && (
-              <div className={`badge badge-sm gap-1.5 ${deviceMemory >= 4 ? 'badge-success' : 'badge-warning'}`}>
-                {deviceMemory} GB device memory
-              </div>
-            )}
-            <div className={`badge badge-sm gap-1.5 ${hasChromeAI ? 'badge-success' : 'badge-ghost'}`}>
-              {hasChromeAI ? 'Chrome AI ready' : 'Chrome AI not available'}
-            </div>
           </div>
 
-          {/* Local preference */}
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Local Model Preference</legend>
-            <select
-              className="select select-bordered select-sm w-full"
-              value={localPref}
-              onChange={(e) => handleLocalPrefChange(e.target.value as LocalPreference)}
-            >
-              <option value="off">Off — cloud only</option>
-              <option value="offline-only">Offline fallback — use local when no internet</option>
-              <option value="always">Always local — prefer local models</option>
-            </select>
-          </fieldset>
+          {/* ---- Version ---- */}
+          <VersionSection />
 
-          {/* Download / preload button for local providers */}
-          {currentProvider.isLocal && currentProvider.id === 'webllm' && !webllmProgress && (
-            <button
-              className="btn btn-outline btn-sm gap-2"
-              onClick={() => orch.preloadModel()}
-            >
-              <Download className="w-4 h-4" /> Download Model
-            </button>
-          )}
-
-          {/* Download progress bar */}
-          {webllmProgress && (
-            <div>
-              <div className="flex items-center gap-2 text-sm">
-                <Download className="w-4 h-4 animate-pulse" />
-                <span className="flex-1 truncate">{webllmProgress.status}</span>
-                <span className="text-xs opacity-60">{Math.round(webllmProgress.progress * 100)}%</span>
-              </div>
-              <progress
-                role="progressbar"
-                className="progress progress-primary w-full h-2 mt-1"
-                value={webllmProgress.progress * 100}
-                max={100}
-              />
-            </div>
-          )}
-
-          <div className="flex items-center gap-2 text-xs opacity-60">
-            {navigator.onLine
-              ? <><Wifi className="w-3 h-3" /> Online</>
-              : <><WifiOff className="w-3 h-3" /> Offline — local models will be used</>
-            }
-          </div>
-
-          {!hasWebGPU && (
-            <p className="text-xs text-warning">
-              WebGPU is required for WebLLM local models. Use Chrome 113+ with WebGPU enabled.
-            </p>
-          )}
-          {deviceMemory !== null && deviceMemory < 4 && (
-            <p className="text-xs text-warning">
-              Less than 4 GB device memory detected. Local models may not run reliably.
-            </p>
-          )}
+          {/* ---- Acknowledgements ---- */}
+          <AcknowledgementsSection />
         </div>
-      </div>
-
-      {/* ---- Assistant Name ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><MessageSquare className="w-4 h-4" /> Assistant Name</h3>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              className="input input-bordered input-sm flex-1"
-              placeholder="Andy"
-              value={assistantName}
-              onChange={(e) => setAssistantName(e.target.value)}
-              onBlur={handleNameSave}
-            />
-          </div>
-          <p className="text-xs opacity-50">
-            The name used for the assistant. Mention @{assistantName} to trigger a response.
-          </p>
-        </div>
-      </div>
-
-      {/* ---- Profile ---- */}
-      <ProfileSection />
-
-      {/* ---- Telegram ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><Smartphone className="w-4 h-4" /> Telegram Bot</h3>
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Bot Token</legend>
-            <input
-              type="password"
-              className="input input-bordered input-sm w-full font-mono"
-              placeholder="123456:ABC-DEF..."
-              value={telegramToken}
-              onChange={(e) => setTelegramToken(e.target.value)}
-            />
-          </fieldset>
-          <fieldset className="fieldset">
-            <legend className="fieldset-legend">Allowed Chat IDs</legend>
-            <input
-              type="text"
-              className="input input-bordered input-sm w-full font-mono"
-              placeholder="-100123456, 789012"
-              value={telegramChatIds}
-              onChange={(e) => setTelegramChatIds(e.target.value)}
-            />
-            <p className="fieldset-label opacity-60">Comma-separated chat IDs</p>
-          </fieldset>
-          <div className="flex items-center gap-2">
-            <button
-              className="btn btn-primary btn-sm"
-              onClick={handleTelegramSave}
-              disabled={!telegramToken.trim()}
-            >
-              Save Telegram Config
-            </button>
-            {telegramSaved && (
-              <span className="text-success text-sm flex items-center gap-1"><Check className="w-4 h-4" /> Saved</span>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* ---- Storage ---- */}
-      <div className="card card-bordered bg-base-200">
-        <div className="card-body p-4 sm:p-6 gap-3">
-          <h3 className="card-title text-base gap-2"><HardDrive className="w-4 h-4" /> Storage</h3>
-          <div>
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span>{formatBytes(storageUsage)} used</span>
-              <span className="opacity-60">
-                of {formatBytes(storageQuota)}
-              </span>
-            </div>
-            <progress
-              className="progress progress-primary w-full h-2"
-              value={storagePercent}
-              max={100}
-            />
-          </div>
-          {!isPersistent && (
-            <button
-              className="btn btn-outline btn-sm"
-              onClick={handleRequestPersistent}
-            >
-              <Lock className="w-4 h-4" /> Request Persistent Storage
-            </button>
-          )}
-          {isPersistent && (
-            <div className="badge badge-success badge-sm gap-1.5">
-              <Lock className="w-3 h-3" /> Persistent storage active
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* ---- Version ---- */}
-      <VersionSection />
-
-      {/* ---- Acknowledgements ---- */}
-      <AcknowledgementsSection />
+      </section>
     </div>
   );
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -607,6 +607,8 @@ export class Orchestrator {
       channel: groupId.startsWith('tg:') ? 'telegram' : 'browser',
       isFromMe: true,
       isTrigger: false,
+      model: this.model,
+      providerId: this.providerId,
     };
     await saveMessage(stored);
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -229,3 +229,48 @@ export async function getStorageEstimate(): Promise<{ usage: number; quota: numb
   }
   return { usage: 0, quota: 0 };
 }
+
+/**
+ * Estimate storage used by WebLLM model weight caches.
+ * WebLLM stores models in the Cache Storage API with cache names
+ * containing "webllm" or "mlc".
+ */
+export async function getModelCacheEstimate(): Promise<number> {
+  if (typeof caches === 'undefined') return 0;
+  try {
+    const keys = await caches.keys();
+    const modelCaches = keys.filter(
+      (k) => k.toLowerCase().includes('webllm') || k.toLowerCase().includes('mlc'),
+    );
+    let totalSize = 0;
+    for (const cacheName of modelCaches) {
+      const cache = await caches.open(cacheName);
+      const cacheKeys = await cache.keys();
+      for (const req of cacheKeys) {
+        const resp = await cache.match(req);
+        if (resp) {
+          const blob = await resp.blob();
+          totalSize += blob.size;
+        }
+      }
+    }
+    return totalSize;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Delete all WebLLM model weight caches to reclaim storage.
+ * Models will be re-downloaded on next use.
+ */
+export async function deleteModelCaches(): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  const keys = await caches.keys();
+  const modelCaches = keys.filter(
+    (k) => k.toLowerCase().includes('webllm') || k.toLowerCase().includes('mlc'),
+  );
+  for (const cacheName of modelCaches) {
+    await caches.delete(cacheName);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,10 @@ export interface InboundMessage {
 export interface StoredMessage extends InboundMessage {
   isFromMe: boolean;
   isTrigger: boolean;
+  /** The model that generated this response (only on assistant messages) */
+  model?: string;
+  /** The provider that generated this response (only on assistant messages) */
+  providerId?: string;
 }
 
 /** Scheduled task */

--- a/tests/components/chat/MessageBubble.test.tsx
+++ b/tests/components/chat/MessageBubble.test.tsx
@@ -269,4 +269,59 @@ describe('MessageBubble', () => {
     const p = container.querySelector('p.my-1');
     expect(p).toBeTruthy();
   });
+
+  // ---- Model badge display ----
+
+  it('displays model label on assistant messages with model field', () => {
+    const msg: StoredMessage = {
+      ...assistantMessage,
+      model: 'claude-sonnet-4-6',
+      providerId: 'anthropic',
+    };
+    const { container } = render(<MessageBubble message={msg} />);
+    expect(container.textContent).toContain('Sonnet 4.6');
+  });
+
+  it('does not display model badge on user messages', () => {
+    const msg: StoredMessage = {
+      ...userMessage,
+      model: 'claude-sonnet-4-6',
+    };
+    const { container } = render(<MessageBubble message={msg} />);
+    expect(container.querySelector('.chat-footer')).toBeNull();
+  });
+
+  it('does not display model badge when model field is missing', () => {
+    const { container } = render(<MessageBubble message={assistantMessage} />);
+    expect(container.querySelector('.chat-footer')).toBeNull();
+  });
+
+  it('shows raw model ID when model is not in labels map', () => {
+    const msg: StoredMessage = {
+      ...assistantMessage,
+      model: 'unknown-model-v1',
+      providerId: 'anthropic',
+    };
+    const { container } = render(<MessageBubble message={msg} />);
+    expect(container.textContent).toContain('unknown-model-v1');
+  });
+
+  it('displays known model labels correctly', () => {
+    const models = [
+      { id: 'claude-opus-4-6', label: 'Opus 4.6' },
+      { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
+      { id: 'qwen3-4b', label: 'Qwen3 4B' },
+      { id: 'gemini-nano', label: 'Gemini Nano' },
+    ];
+
+    for (const { id, label } of models) {
+      const msg: StoredMessage = {
+        ...assistantMessage,
+        model: id,
+        providerId: 'anthropic',
+      };
+      const { container } = render(<MessageBubble message={msg} />);
+      expect(container.textContent).toContain(label);
+    }
+  });
 });

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -56,9 +56,13 @@ vi.mock('../../../src/stores/theme-store', () => ({
 }));
 
 const mockRequestPersistentStorage = vi.fn().mockResolvedValue(true);
+const mockGetModelCacheEstimate = vi.fn().mockResolvedValue(0);
+const mockDeleteModelCaches = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../../src/storage', () => ({
   getStorageEstimate: vi.fn().mockResolvedValue({ usage: 1024, quota: 1073741824 }),
   requestPersistentStorage: (...args: any[]) => mockRequestPersistentStorage(...args),
+  getModelCacheEstimate: (...args: any[]) => mockGetModelCacheEstimate(...args),
+  deleteModelCaches: (...args: any[]) => mockDeleteModelCaches(...args),
 }));
 
 // Mock DB to prevent IndexedDB calls during render
@@ -92,6 +96,7 @@ describe('SettingsPage', () => {
     mockProviderId = 'anthropic';
     mockModel = 'claude-sonnet-4-6';
     mockWebllmProgress = null;
+    mockGetModelCacheEstimate.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -117,6 +122,16 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Storage')).toBeInTheDocument();
     expect(screen.getByText('Version')).toBeInTheDocument();
     expect(screen.getByText('Acknowledgements')).toBeInTheDocument();
+  });
+
+  // ---- Semantic grouping ----
+
+  it('renders semantic group headings', () => {
+    render(<SettingsPage />);
+    expect(screen.getByText('AI & Models')).toBeInTheDocument();
+    expect(screen.getByText('Personalization')).toBeInTheDocument();
+    expect(screen.getByText('Integrations')).toBeInTheDocument();
+    expect(screen.getByText('Storage & System')).toBeInTheDocument();
   });
 
   // ---- Theme selection ----
@@ -369,6 +384,85 @@ describe('SettingsPage', () => {
     });
 
     expect(mockRequestPersistentStorage).toHaveBeenCalled();
+  });
+
+  // ---- Storage breakdown ----
+
+  it('shows storage breakdown with model weights and other data', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(524288); // 512 KB
+
+    const { getStorageEstimate } = await import('../../../src/storage');
+    (getStorageEstimate as any).mockResolvedValue({ usage: 1048576, quota: 1073741824 }); // 1 MB
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Model weights')).toBeInTheDocument();
+      expect(screen.getByText('Other data')).toBeInTheDocument();
+      // Both model weights and other data show 512.0 KB
+      const kbTexts = screen.getAllByText('512.0 KB');
+      expect(kbTexts.length).toBe(2);
+    });
+  });
+
+  it('shows Delete Model Weights button when cache has data', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(1048576); // 1 MB
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Model Weights')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show Delete Model Weights button when cache is empty', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(0);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    expect(screen.queryByText('Delete Model Weights')).toBeNull();
+  });
+
+  it('calls deleteModelCaches and refreshes storage when delete is clicked', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(1048576);
+
+    const { getStorageEstimate } = await import('../../../src/storage');
+    (getStorageEstimate as any).mockResolvedValue({ usage: 2097152, quota: 1073741824 });
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Model Weights')).toBeInTheDocument();
+    });
+
+    // After delete, getStorageEstimate returns reduced usage
+    (getStorageEstimate as any).mockResolvedValue({ usage: 1048576, quota: 1073741824 });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete Model Weights'));
+    });
+
+    expect(mockDeleteModelCaches).toHaveBeenCalled();
+  });
+
+  it('shows re-download notice when model cache exists', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(1048576);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Models will be re-downloaded/)).toBeInTheDocument();
+    });
   });
 
   // ---- Persistent storage already granted ----

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -7,6 +7,8 @@ import {
   requestPersistentStorage,
   getStorageEstimate,
   migrateFromLegacyOpfs,
+  getModelCacheEstimate,
+  deleteModelCaches,
 } from '../src/storage';
 
 const GROUP = 'br:test-storage';
@@ -355,6 +357,156 @@ describe('storage (OPFS)', () => {
         writable: true,
         configurable: true,
       });
+    });
+  });
+
+  describe('getModelCacheEstimate', () => {
+    // In-memory CacheStorage polyfill for happy-dom
+    let mockCacheStore: Map<string, Map<string, Response>>;
+    let origCaches: typeof globalThis.caches;
+
+    beforeEach(() => {
+      origCaches = globalThis.caches;
+      mockCacheStore = new Map();
+      const mockCaches = {
+        open: async (name: string) => {
+          if (!mockCacheStore.has(name)) mockCacheStore.set(name, new Map());
+          const store = mockCacheStore.get(name)!;
+          return {
+            put: async (req: Request | string, resp: Response) => {
+              const url = typeof req === 'string' ? req : req.url;
+              store.set(url, resp.clone());
+            },
+            keys: async () => [...store.keys()].map((u) => new Request(u)),
+            match: async (req: Request) => store.get(req.url)?.clone() ?? undefined,
+          };
+        },
+        keys: async () => [...mockCacheStore.keys()],
+        delete: async (name: string) => {
+          const had = mockCacheStore.has(name);
+          mockCacheStore.delete(name);
+          return had;
+        },
+      } as unknown as CacheStorage;
+      Object.defineProperty(globalThis, 'caches', { value: mockCaches, writable: true, configurable: true });
+    });
+
+    afterEach(() => {
+      if (origCaches !== undefined) {
+        Object.defineProperty(globalThis, 'caches', { value: origCaches, writable: true, configurable: true });
+      } else {
+        // @ts-expect-error — restore undefined
+        delete globalThis.caches;
+      }
+    });
+
+    it('returns 0 when caches API is undefined', async () => {
+      // @ts-expect-error — removing caches for testing
+      delete globalThis.caches;
+      const result = await getModelCacheEstimate();
+      expect(result).toBe(0);
+    });
+
+    it('returns 0 when no webllm/mlc caches exist', async () => {
+      const result = await getModelCacheEstimate();
+      expect(result).toBe(0);
+    });
+
+    it('estimates size of webllm caches', async () => {
+      const cache = await caches.open('webllm-test-cache');
+      await cache.put(
+        new Request('https://example.com/model.bin'),
+        new Response('x'.repeat(1024)),
+      );
+      const estimate = await getModelCacheEstimate();
+      expect(estimate).toBeGreaterThanOrEqual(1024);
+    });
+
+    it('estimates size of mlc caches', async () => {
+      const cache = await caches.open('mlc-model-cache');
+      await cache.put(
+        new Request('https://example.com/weights.bin'),
+        new Response('y'.repeat(512)),
+      );
+      const estimate = await getModelCacheEstimate();
+      expect(estimate).toBeGreaterThanOrEqual(512);
+    });
+
+    it('ignores non-model caches', async () => {
+      const cache = await caches.open('my-app-cache');
+      await cache.put(
+        new Request('https://example.com/app.js'),
+        new Response('z'.repeat(2048)),
+      );
+      const estimate = await getModelCacheEstimate();
+      expect(estimate).toBe(0);
+    });
+  });
+
+  describe('deleteModelCaches', () => {
+    let mockCacheStore: Map<string, Map<string, Response>>;
+    let origCaches: typeof globalThis.caches;
+
+    beforeEach(() => {
+      origCaches = globalThis.caches;
+      mockCacheStore = new Map();
+      const mockCaches = {
+        open: async (name: string) => {
+          if (!mockCacheStore.has(name)) mockCacheStore.set(name, new Map());
+          return {};
+        },
+        keys: async () => [...mockCacheStore.keys()],
+        delete: async (name: string) => {
+          const had = mockCacheStore.has(name);
+          mockCacheStore.delete(name);
+          return had;
+        },
+      } as unknown as CacheStorage;
+      Object.defineProperty(globalThis, 'caches', { value: mockCaches, writable: true, configurable: true });
+    });
+
+    afterEach(() => {
+      if (origCaches !== undefined) {
+        Object.defineProperty(globalThis, 'caches', { value: origCaches, writable: true, configurable: true });
+      } else {
+        // @ts-expect-error — restore undefined
+        delete globalThis.caches;
+      }
+    });
+
+    it('does nothing when caches API is undefined', async () => {
+      // @ts-expect-error — removing caches for testing
+      delete globalThis.caches;
+      await expect(deleteModelCaches()).resolves.toBeUndefined();
+    });
+
+    it('deletes webllm caches', async () => {
+      await caches.open('webllm-model-weights');
+      const keysBefore = await caches.keys();
+      expect(keysBefore).toContain('webllm-model-weights');
+
+      await deleteModelCaches();
+
+      const keysAfter = await caches.keys();
+      expect(keysAfter).not.toContain('webllm-model-weights');
+    });
+
+    it('deletes mlc caches', async () => {
+      await caches.open('mlc-engine-cache');
+      await deleteModelCaches();
+      const keys = await caches.keys();
+      expect(keys).not.toContain('mlc-engine-cache');
+    });
+
+    it('preserves non-model caches', async () => {
+      await caches.open('app-static-cache');
+      await caches.open('webllm-to-delete');
+
+      await deleteModelCaches();
+
+      const keys = await caches.keys();
+      expect(keys).toContain('app-static-cache');
+      expect(keys).not.toContain('webllm-to-delete');
     });
   });
 });


### PR DESCRIPTION
- Restructure settings into semantic groups: AI & Models, Personalization,
  Integrations, Storage & System
- Add storage breakdown showing model weights vs other data
- Add ability to delete cached model weights to reclaim storage
- Display the active model name on assistant message bubbles
- Add model/providerId fields to StoredMessage type
- Update unit tests, E2E tests, and maintain >90% coverage

Closes #62

https://claude.ai/code/session_01X93zjykbWmWkUmToNGk53D