### PR TITLE
List downloaded models individually with delete and spec links

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState } from 'react';
 import {
   Palette, KeyRound, Eye, EyeOff, Bot, MessageSquare,
-  Smartphone, HardDrive, Lock, Check, Cpu, Wifi, WifiOff, Download, Trash2,
+  Smartphone, HardDrive, Lock, Check, Cpu, Wifi, WifiOff, Download, Trash2, ExternalLink,
 } from 'lucide-react';
 import { getConfig } from '../../db.js';
 import { CONFIG_KEYS } from '../../config.js';
@@ -14,7 +14,10 @@ import {
   requestPersistentStorage,
   getModelCacheEstimate,
   deleteModelCaches,
+  listModelCaches,
+  deleteModelCache,
 } from '../../storage.js';
+import type { ModelCacheInfo } from '../../storage.js';
 import { decryptValue } from '../../crypto.js';
 import { getOrchestrator, useOrchestratorStore } from '../../stores/orchestrator-store.js';
 import { useThemeStore, type ThemeChoice } from '../../stores/theme-store.js';
@@ -84,6 +87,29 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(k, i)).toFixed(1)} ${units[i]}`;
 }
 
+/**
+ * Extract a short display name from a cache name.
+ * e.g. "webllm/model/Qwen3-0.6B-q4f16_1-MLC" → "Qwen3-0.6B"
+ */
+function cacheDisplayName(cacheName: string): string {
+  // Try to extract model name from path-style cache names
+  const parts = cacheName.split('/');
+  const last = parts[parts.length - 1];
+  // Remove quantization suffix: "-q4f16_1-MLC" or similar
+  const cleaned = last.replace(/-q\d+f\d+_\d+-MLC$/i, '');
+  return cleaned || last;
+}
+
+/**
+ * Build a HuggingFace URL for the MLC model.
+ * e.g. "webllm/model/Qwen3-0.6B-q4f16_1-MLC" → "https://huggingface.co/mlc-ai/Qwen3-0.6B-q4f16_1-MLC"
+ */
+function cacheModelUrl(cacheName: string): string {
+  const parts = cacheName.split('/');
+  const modelId = parts[parts.length - 1];
+  return `https://huggingface.co/mlc-ai/${modelId}`;
+}
+
 export function SettingsPage() {
   const orch = getOrchestrator();
 
@@ -123,6 +149,7 @@ export function SettingsPage() {
   const [isPersistent, setIsPersistent] = useState(false);
   const [modelCacheSize, setModelCacheSize] = useState(0);
   const [deletingCache, setDeletingCache] = useState(false);
+  const [cachedModels, setCachedModels] = useState<ModelCacheInfo[]>([]);
 
   // Theme
   const { theme, setTheme } = useThemeStore();
@@ -161,9 +188,11 @@ export function SettingsPage() {
         setIsPersistent(await navigator.storage.persisted());
       }
 
-      // Model cache size
+      // Model cache size and individual models
       const cacheSize = await getModelCacheEstimate();
       setModelCacheSize(cacheSize);
+      const models = await listModelCaches();
+      setCachedModels(models);
 
       // Hardware checks
       setHasWebGPU('gpu' in navigator);
@@ -243,11 +272,24 @@ export function SettingsPage() {
     setDeletingCache(true);
     await deleteModelCaches();
     setModelCacheSize(0);
+    setCachedModels([]);
     // Refresh total storage estimate
     const est = await getStorageEstimate();
     setStorageUsage(est.usage);
     setStorageQuota(est.quota);
     setDeletingCache(false);
+  }
+
+  async function handleDeleteSingleModelCache(cacheName: string) {
+    await deleteModelCache(cacheName);
+    // Refresh cache list and sizes
+    const models = await listModelCaches();
+    setCachedModels(models);
+    const cacheSize = await getModelCacheEstimate();
+    setModelCacheSize(cacheSize);
+    const est = await getStorageEstimate();
+    setStorageUsage(est.usage);
+    setStorageQuota(est.quota);
   }
 
   const storagePercent = storageQuota > 0 ? (storageUsage / storageQuota) * 100 : 0;
@@ -597,7 +639,39 @@ export function SettingsPage() {
                 </div>
               </div>
 
-              {/* Delete model weights */}
+              {/* Individual cached models */}
+              {cachedModels.length > 0 && (
+                <div>
+                  <h4 className="font-semibold text-sm mb-2">Downloaded Models</h4>
+                  <div className="space-y-2">
+                    {cachedModels.map((m) => (
+                      <div key={m.cacheName} className="flex items-center justify-between gap-2 text-sm">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <a
+                            href={cacheModelUrl(m.cacheName)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="link link-hover flex items-center gap-1 truncate"
+                          >
+                            {cacheDisplayName(m.cacheName)}
+                            <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                          </a>
+                          <span className="text-xs opacity-60 font-mono flex-shrink-0">{formatBytes(m.size)}</span>
+                        </div>
+                        <button
+                          className="btn btn-ghost btn-xs text-error"
+                          aria-label={`Delete ${cacheDisplayName(m.cacheName)} cache`}
+                          onClick={() => handleDeleteSingleModelCache(m.cacheName)}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Delete all model weights */}
               {modelCacheSize > 0 && (
                 <button
                   className="btn btn-outline btn-error btn-sm gap-2"
@@ -605,7 +679,7 @@ export function SettingsPage() {
                   disabled={deletingCache}
                 >
                   <Trash2 className="w-4 h-4" />
-                  {deletingCache ? 'Deleting...' : 'Delete Model Weights'}
+                  {deletingCache ? 'Deleting...' : 'Delete All Model Weights'}
                 </button>
               )}
               {modelCacheSize > 0 && (

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -274,3 +274,48 @@ export async function deleteModelCaches(): Promise<void> {
     await caches.delete(cacheName);
   }
 }
+
+/** Info about a single cached model */
+export interface ModelCacheInfo {
+  cacheName: string;
+  size: number;
+}
+
+/**
+ * List individual WebLLM/MLC model caches with their sizes.
+ * Returns one entry per cache (each cache typically corresponds to one model).
+ */
+export async function listModelCaches(): Promise<ModelCacheInfo[]> {
+  if (typeof caches === 'undefined') return [];
+  try {
+    const keys = await caches.keys();
+    const modelCacheNames = keys.filter(
+      (k) => k.toLowerCase().includes('webllm') || k.toLowerCase().includes('mlc'),
+    );
+    const results: ModelCacheInfo[] = [];
+    for (const cacheName of modelCacheNames) {
+      const cache = await caches.open(cacheName);
+      const cacheKeys = await cache.keys();
+      let size = 0;
+      for (const req of cacheKeys) {
+        const resp = await cache.match(req);
+        if (resp) {
+          const blob = await resp.blob();
+          size += blob.size;
+        }
+      }
+      results.push({ cacheName, size });
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Delete a single model cache by name.
+ */
+export async function deleteModelCache(cacheName: string): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  await caches.delete(cacheName);
+}

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -58,11 +58,15 @@ vi.mock('../../../src/stores/theme-store', () => ({
 const mockRequestPersistentStorage = vi.fn().mockResolvedValue(true);
 const mockGetModelCacheEstimate = vi.fn().mockResolvedValue(0);
 const mockDeleteModelCaches = vi.fn().mockResolvedValue(undefined);
+const mockListModelCaches = vi.fn().mockResolvedValue([]);
+const mockDeleteModelCache = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../../src/storage', () => ({
   getStorageEstimate: vi.fn().mockResolvedValue({ usage: 1024, quota: 1073741824 }),
   requestPersistentStorage: (...args: any[]) => mockRequestPersistentStorage(...args),
   getModelCacheEstimate: (...args: any[]) => mockGetModelCacheEstimate(...args),
   deleteModelCaches: (...args: any[]) => mockDeleteModelCaches(...args),
+  listModelCaches: (...args: any[]) => mockListModelCaches(...args),
+  deleteModelCache: (...args: any[]) => mockDeleteModelCache(...args),
 }));
 
 // Mock DB to prevent IndexedDB calls during render
@@ -97,6 +101,8 @@ describe('SettingsPage', () => {
     mockModel = 'claude-sonnet-4-6';
     mockWebllmProgress = null;
     mockGetModelCacheEstimate.mockResolvedValue(0);
+    mockListModelCaches.mockResolvedValue([]);
+    mockDeleteModelCache.mockClear();
   });
 
   afterEach(() => {
@@ -407,7 +413,7 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('shows Delete Model Weights button when cache has data', async () => {
+  it('shows Delete All Model Weights button when cache has data', async () => {
     mockGetModelCacheEstimate.mockResolvedValue(1048576); // 1 MB
 
     await act(async () => {
@@ -415,18 +421,18 @@ describe('SettingsPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Delete Model Weights')).toBeInTheDocument();
+      expect(screen.getByText('Delete All Model Weights')).toBeInTheDocument();
     });
   });
 
-  it('does not show Delete Model Weights button when cache is empty', async () => {
+  it('does not show Delete All Model Weights button when cache is empty', async () => {
     mockGetModelCacheEstimate.mockResolvedValue(0);
 
     await act(async () => {
       render(<SettingsPage />);
     });
 
-    expect(screen.queryByText('Delete Model Weights')).toBeNull();
+    expect(screen.queryByText('Delete All Model Weights')).toBeNull();
   });
 
   it('calls deleteModelCaches and refreshes storage when delete is clicked', async () => {
@@ -440,14 +446,14 @@ describe('SettingsPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Delete Model Weights')).toBeInTheDocument();
+      expect(screen.getByText('Delete All Model Weights')).toBeInTheDocument();
     });
 
     // After delete, getStorageEstimate returns reduced usage
     (getStorageEstimate as any).mockResolvedValue({ usage: 1048576, quota: 1073741824 });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Delete Model Weights'));
+      fireEvent.click(screen.getByText('Delete All Model Weights'));
     });
 
     expect(mockDeleteModelCaches).toHaveBeenCalled();
@@ -770,5 +776,116 @@ describe('SettingsPage', () => {
     expect(screen.getByText(/Downloading/)).toBeInTheDocument();
     // Multiple progressbars exist (storage + model download)
     expect(screen.getAllByRole('progressbar').length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ---- Individual model cache listing ----
+
+  it('lists individual cached models with sizes', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(3072);
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-0.6B-q4f16_1-MLC', size: 1024 },
+      { cacheName: 'webllm/model/Qwen3-4B-q4f16_1-MLC', size: 2048 },
+    ]);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Qwen3-0\.6B/)).toBeInTheDocument();
+      expect(screen.getByText(/Qwen3-4B/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows individual delete buttons for each cached model', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(2048);
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-0.6B-q4f16_1-MLC', size: 1024 },
+      { cacheName: 'webllm/model/Qwen3-4B-q4f16_1-MLC', size: 1024 },
+    ]);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      const deleteButtons = screen.getAllByLabelText(/Delete .* cache/);
+      expect(deleteButtons.length).toBe(2);
+    });
+  });
+
+  it('deletes individual model cache when its delete button is clicked', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(2048);
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-0.6B-q4f16_1-MLC', size: 1024 },
+      { cacheName: 'webllm/model/Qwen3-4B-q4f16_1-MLC', size: 1024 },
+    ]);
+
+    const { getStorageEstimate } = await import('../../../src/storage');
+    (getStorageEstimate as any).mockResolvedValue({ usage: 2048, quota: 1073741824 });
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    // After delete, update mocks to reflect removal
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-4B-q4f16_1-MLC', size: 1024 },
+    ]);
+    mockGetModelCacheEstimate.mockResolvedValue(1024);
+    (getStorageEstimate as any).mockResolvedValue({ usage: 1024, quota: 1073741824 });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Delete .* cache/).length).toBe(2);
+    });
+
+    await act(async () => {
+      const deleteButtons = screen.getAllByLabelText(/Delete .* cache/);
+      fireEvent.click(deleteButtons[0]);
+    });
+
+    expect(mockDeleteModelCache).toHaveBeenCalledWith('webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+  });
+
+  it('shows model spec links for cached models', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(1024);
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-0.6B-q4f16_1-MLC', size: 1024 },
+    ]);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /Qwen3-0\.6B/ });
+      expect(link).toHaveAttribute('href', expect.stringContaining('huggingface.co'));
+    });
+  });
+
+  it('does not show cached models list when no models are cached', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(0);
+    mockListModelCaches.mockResolvedValue([]);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    expect(screen.queryByText('Downloaded Models')).toBeNull();
+  });
+
+  it('shows Downloaded Models heading when models are cached', async () => {
+    mockGetModelCacheEstimate.mockResolvedValue(1024);
+    mockListModelCaches.mockResolvedValue([
+      { cacheName: 'webllm/model/Qwen3-0.6B-q4f16_1-MLC', size: 1024 },
+    ]);
+
+    await act(async () => {
+      render(<SettingsPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Downloaded Models')).toBeInTheDocument();
+    });
   });
 });

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -9,6 +9,8 @@ import {
   migrateFromLegacyOpfs,
   getModelCacheEstimate,
   deleteModelCaches,
+  listModelCaches,
+  deleteModelCache,
 } from '../src/storage';
 
 const GROUP = 'br:test-storage';
@@ -507,6 +509,172 @@ describe('storage (OPFS)', () => {
       const keys = await caches.keys();
       expect(keys).toContain('app-static-cache');
       expect(keys).not.toContain('webllm-to-delete');
+    });
+  });
+
+  describe('listModelCaches', () => {
+    let mockCacheStore: Map<string, Map<string, Response>>;
+    let origCaches: typeof globalThis.caches;
+
+    beforeEach(() => {
+      origCaches = globalThis.caches;
+      mockCacheStore = new Map();
+      const mockCaches = {
+        open: async (name: string) => {
+          if (!mockCacheStore.has(name)) mockCacheStore.set(name, new Map());
+          const store = mockCacheStore.get(name)!;
+          return {
+            put: async (req: Request | string, resp: Response) => {
+              const url = typeof req === 'string' ? req : req.url;
+              store.set(url, resp.clone());
+            },
+            keys: async () => [...store.keys()].map((u) => new Request(u)),
+            match: async (req: Request) => store.get(req.url)?.clone() ?? undefined,
+          };
+        },
+        keys: async () => [...mockCacheStore.keys()],
+        delete: async (name: string) => {
+          const had = mockCacheStore.has(name);
+          mockCacheStore.delete(name);
+          return had;
+        },
+      } as unknown as CacheStorage;
+      Object.defineProperty(globalThis, 'caches', { value: mockCaches, writable: true, configurable: true });
+    });
+
+    afterEach(() => {
+      if (origCaches !== undefined) {
+        Object.defineProperty(globalThis, 'caches', { value: origCaches, writable: true, configurable: true });
+      } else {
+        // @ts-expect-error — restore undefined
+        delete globalThis.caches;
+      }
+    });
+
+    it('returns empty array when caches API is undefined', async () => {
+      // @ts-expect-error — removing caches for testing
+      delete globalThis.caches;
+      const result = await listModelCaches();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no model caches exist', async () => {
+      const result = await listModelCaches();
+      expect(result).toEqual([]);
+    });
+
+    it('lists individual webllm/mlc caches with sizes', async () => {
+      const cache1 = await caches.open('webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+      await cache1.put(
+        new Request('https://example.com/weights-part1.bin'),
+        new Response('x'.repeat(1024)),
+      );
+
+      const cache2 = await caches.open('webllm/model/Qwen3-4B-q4f16_1-MLC');
+      await cache2.put(
+        new Request('https://example.com/weights-part1.bin'),
+        new Response('y'.repeat(2048)),
+      );
+      await cache2.put(
+        new Request('https://example.com/weights-part2.bin'),
+        new Response('z'.repeat(512)),
+      );
+
+      const result = await listModelCaches();
+      expect(result).toHaveLength(2);
+
+      const cache1Info = result.find((c) => c.cacheName === 'webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+      expect(cache1Info).toBeDefined();
+      expect(cache1Info!.size).toBeGreaterThanOrEqual(1024);
+
+      const cache2Info = result.find((c) => c.cacheName === 'webllm/model/Qwen3-4B-q4f16_1-MLC');
+      expect(cache2Info).toBeDefined();
+      expect(cache2Info!.size).toBeGreaterThanOrEqual(2560);
+    });
+
+    it('ignores non-model caches', async () => {
+      const appCache = await caches.open('app-static-cache');
+      await appCache.put(
+        new Request('https://example.com/app.js'),
+        new Response('code'),
+      );
+
+      const modelCache = await caches.open('mlc-model-cache');
+      await modelCache.put(
+        new Request('https://example.com/weights.bin'),
+        new Response('w'.repeat(512)),
+      );
+
+      const result = await listModelCaches();
+      expect(result).toHaveLength(1);
+      expect(result[0].cacheName).toBe('mlc-model-cache');
+    });
+
+    it('returns cacheName and size for each cache entry', async () => {
+      const cache = await caches.open('webllm-test');
+      await cache.put(
+        new Request('https://example.com/model.bin'),
+        new Response('data'),
+      );
+
+      const result = await listModelCaches();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('cacheName', 'webllm-test');
+      expect(result[0]).toHaveProperty('size');
+      expect(typeof result[0].size).toBe('number');
+    });
+  });
+
+  describe('deleteModelCache', () => {
+    let mockCacheStore: Map<string, Map<string, Response>>;
+    let origCaches: typeof globalThis.caches;
+
+    beforeEach(() => {
+      origCaches = globalThis.caches;
+      mockCacheStore = new Map();
+      const mockCaches = {
+        open: async (name: string) => {
+          if (!mockCacheStore.has(name)) mockCacheStore.set(name, new Map());
+          return {};
+        },
+        keys: async () => [...mockCacheStore.keys()],
+        delete: async (name: string) => {
+          const had = mockCacheStore.has(name);
+          mockCacheStore.delete(name);
+          return had;
+        },
+      } as unknown as CacheStorage;
+      Object.defineProperty(globalThis, 'caches', { value: mockCaches, writable: true, configurable: true });
+    });
+
+    afterEach(() => {
+      if (origCaches !== undefined) {
+        Object.defineProperty(globalThis, 'caches', { value: origCaches, writable: true, configurable: true });
+      } else {
+        // @ts-expect-error — restore undefined
+        delete globalThis.caches;
+      }
+    });
+
+    it('does nothing when caches API is undefined', async () => {
+      // @ts-expect-error — removing caches for testing
+      delete globalThis.caches;
+      await expect(deleteModelCache('some-cache')).resolves.toBeUndefined();
+    });
+
+    it('deletes a specific model cache by name', async () => {
+      await caches.open('webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+      await caches.open('webllm/model/Qwen3-4B-q4f16_1-MLC');
+
+      await deleteModelCache('webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+
+      const keys = await caches.keys();
+      expect(keys).not.toContain('webllm/model/Qwen3-0.6B-q4f16_1-MLC');
+      expect(keys).toContain('webllm/model/Qwen3-4B-q4f16_1-MLC');
+    });
+
+    it('does not error when cache does not exist', async () => {
+      await expect(deleteModelCache('nonexistent-cache')).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Add per-model cache listing in Settings storage section so users can see
which offline models are downloaded, their sizes, links to HuggingFace
model specs, and delete them individually instead of only in bulk.

- Add listModelCaches() and deleteModelCache() to storage.ts
- Update SettingsPage to show individual cached models with size,
  spec link, and per-model delete button
- Rename bulk delete button to "Delete All Model Weights"
- Add unit tests for new storage functions and UI components

Closes #68

https://claude.ai/code/session_01JKJ5XxAX3WoyAf8M3vR8Sg