### PR TITLE
Add model selector to chat tab for inline provider/model switching

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -31,4 +31,21 @@ test.describe('Chat page', () => {
     await textarea.fill('Hello, SafeClaw!');
     await expect(textarea).toHaveValue('Hello, SafeClaw!');
   });
+
+  test('model selector is visible in chat', async ({ page }) => {
+    const modelSelect = page.locator('select[aria-label="Select AI model"]');
+    await expect(modelSelect).toBeVisible();
+  });
+
+  test('model selector shows provider groups', async ({ page }) => {
+    const modelSelect = page.locator('select[aria-label="Select AI model"]');
+    const optgroups = modelSelect.locator('optgroup');
+    await expect(optgroups).toHaveCount(4);
+  });
+
+  test('can change model in chat', async ({ page }) => {
+    const modelSelect = page.locator('select[aria-label="Select AI model"]');
+    await modelSelect.selectOption('gemini:gemini-2.0-flash');
+    await expect(modelSelect).toHaveValue('gemini:gemini-2.0-flash');
+  });
 });

--- a/src/components/chat/ChatPage.tsx
+++ b/src/components/chat/ChatPage.tsx
@@ -7,6 +7,7 @@ import { X, MessageSquare, Globe, FileText, MapPin, Download } from 'lucide-reac
 import { useOrchestratorStore } from '../../stores/orchestrator-store.js';
 import { MessageList } from './MessageList.js';
 import { ChatInput } from './ChatInput.js';
+import { ModelSelector } from './ModelSelector.js';
 import { TypingIndicator } from './TypingIndicator.js';
 import { ToolActivity } from './ToolActivity.js';
 import { ActivityLog } from './ActivityLog.js';
@@ -157,7 +158,10 @@ export function ChatPage() {
           </div>
         )}
 
-        {/* Input */}
+        {/* Model selector + Input */}
+        <div className="px-4 pt-1">
+          <ModelSelector />
+        </div>
         <ChatInput
           onSend={sendMessage}
           disabled={orchState !== 'idle'}

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — Model selector for the chat input area
+// ---------------------------------------------------------------------------
+
+import { useOrchestratorStore } from '../../stores/orchestrator-store.js';
+import { PROVIDERS } from '../../providers/models.js';
+import type { ProviderId } from '../../providers/types.js';
+
+export function ModelSelector() {
+  const providerId = useOrchestratorStore((s) => s.providerId);
+  const model = useOrchestratorStore((s) => s.model);
+  const orchState = useOrchestratorStore((s) => s.state);
+  const setProviderId = useOrchestratorStore((s) => s.setProviderId);
+  const setModel = useOrchestratorStore((s) => s.setModel);
+
+  const currentValue = `${providerId}:${model}`;
+
+  function handleChange(combinedValue: string) {
+    const [newProviderId, ...modelParts] = combinedValue.split(':');
+    const newModel = modelParts.join(':');
+
+    if (newProviderId !== providerId) {
+      setProviderId(newProviderId as ProviderId);
+    }
+    setModel(newModel);
+  }
+
+  return (
+    <select
+      className="select select-ghost select-xs text-xs opacity-70 hover:opacity-100 focus:opacity-100 min-h-0 h-6 pl-1 pr-6"
+      value={currentValue}
+      onChange={(e) => handleChange(e.target.value)}
+      disabled={orchState !== 'idle'}
+      aria-label="Select AI model"
+    >
+      {PROVIDERS.map((provider) => (
+        <optgroup key={provider.id} label={provider.label}>
+          {provider.models.map((m) => (
+            <option key={m.value} value={`${provider.id}:${m.value}`}>
+              {m.label}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </select>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -19,62 +19,10 @@ import { decryptValue } from '../../crypto.js';
 import { getOrchestrator, useOrchestratorStore } from '../../stores/orchestrator-store.js';
 import { useThemeStore, type ThemeChoice } from '../../stores/theme-store.js';
 import type { ProviderId, LocalPreference } from '../../providers/types.js';
+import { PROVIDERS } from '../../providers/models.js';
 import { ProfileSection } from './ProfileSection.js';
 import { VersionSection } from './VersionSection.js';
 import { AcknowledgementsSection } from './AcknowledgementsSection.js';
-
-// ---------------------------------------------------------------------------
-// Provider / model definitions
-// ---------------------------------------------------------------------------
-
-type ProviderInfo = {
-  id: ProviderId;
-  label: string;
-  isLocal: boolean;
-  models: { value: string; label: string }[];
-};
-
-const PROVIDERS: ProviderInfo[] = [
-  {
-    id: 'anthropic',
-    label: 'Anthropic Claude',
-    isLocal: false,
-    models: [
-      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-      { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
-    ],
-  },
-  {
-    id: 'gemini',
-    label: 'Google Gemini',
-    isLocal: false,
-    models: [
-      { value: 'gemini-2.5-pro-preview-06-05', label: 'Gemini 2.5 Pro' },
-      { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
-      { value: 'gemini-2.0-flash-lite', label: 'Gemini 2.0 Flash Lite' },
-    ],
-  },
-  {
-    id: 'webllm',
-    label: 'WebLLM (Local)',
-    isLocal: true,
-    models: [
-      { value: 'qwen3-0.6b', label: 'Qwen3 0.6B (400 MB)' },
-      { value: 'qwen3-1.7b', label: 'Qwen3 1.7B (1 GB)' },
-      { value: 'qwen3-4b', label: 'Qwen3 4B (2.5 GB)' },
-      { value: 'qwen3-30b', label: 'Qwen3 30B-A3B (16 GB)' },
-    ],
-  },
-  {
-    id: 'chrome-ai',
-    label: 'Chrome AI (Gemini Nano)',
-    isLocal: true,
-    models: [
-      { value: 'gemini-nano', label: 'Gemini Nano (built-in)' },
-    ],
-  },
-];
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';

--- a/src/providers/models.ts
+++ b/src/providers/models.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// SafeClaw — Provider & model definitions (shared between Settings and Chat)
+// ---------------------------------------------------------------------------
+
+import type { ProviderId } from './types.js';
+
+export interface ProviderInfo {
+  id: ProviderId;
+  label: string;
+  isLocal: boolean;
+  models: { value: string; label: string }[];
+}
+
+export const PROVIDERS: ProviderInfo[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic Claude',
+    isLocal: false,
+    models: [
+      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
+      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
+    ],
+  },
+  {
+    id: 'gemini',
+    label: 'Google Gemini',
+    isLocal: false,
+    models: [
+      { value: 'gemini-2.5-pro-preview-06-05', label: 'Gemini 2.5 Pro' },
+      { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
+      { value: 'gemini-2.0-flash-lite', label: 'Gemini 2.0 Flash Lite' },
+    ],
+  },
+  {
+    id: 'webllm',
+    label: 'WebLLM (Local)',
+    isLocal: true,
+    models: [
+      { value: 'qwen3-0.6b', label: 'Qwen3 0.6B (400 MB)' },
+      { value: 'qwen3-1.7b', label: 'Qwen3 1.7B (1 GB)' },
+      { value: 'qwen3-4b', label: 'Qwen3 4B (2.5 GB)' },
+      { value: 'qwen3-30b', label: 'Qwen3 30B-A3B (16 GB)' },
+    ],
+  },
+  {
+    id: 'chrome-ai',
+    label: 'Chrome AI (Gemini Nano)',
+    isLocal: true,
+    models: [
+      { value: 'gemini-nano', label: 'Gemini Nano (built-in)' },
+    ],
+  },
+];
+
+/**
+ * Find the display label for a model value string.
+ * Returns the model value itself if not found.
+ */
+export function getModelLabel(modelValue: string): string {
+  for (const provider of PROVIDERS) {
+    const match = provider.models.find((m) => m.value === modelValue);
+    if (match) return match.label;
+  }
+  return modelValue;
+}
+
+/**
+ * Find the provider that owns a given model value.
+ */
+export function getProviderForModel(modelValue: string): ProviderInfo | undefined {
+  return PROVIDERS.find((p) => p.models.some((m) => m.value === modelValue));
+}

--- a/src/stores/orchestrator-store.ts
+++ b/src/stores/orchestrator-store.ts
@@ -10,8 +10,9 @@ import type {
   ThinkingLogEntry,
 } from '../types.js';
 import type { Orchestrator } from '../orchestrator.js';
-import { DEFAULT_GROUP_ID } from '../config.js';
+import { DEFAULT_GROUP_ID, DEFAULT_MODEL, DEFAULT_PROVIDER } from '../config.js';
 import { getRecentMessages } from '../db.js';
+import type { ProviderId } from '../providers/types.js';
 
 interface WebLLMProgress {
   model: string;
@@ -31,6 +32,8 @@ interface OrchestratorStoreState {
   activeGroupId: string;
   ready: boolean;
   webllmProgress: WebLLMProgress | null;
+  providerId: ProviderId;
+  model: string;
 
   // --- actions ---
   sendMessage: (text: string) => void;
@@ -38,6 +41,8 @@ interface OrchestratorStoreState {
   compactContext: () => Promise<void>;
   clearError: () => void;
   loadHistory: () => Promise<void>;
+  setProviderId: (id: ProviderId) => Promise<void>;
+  setModel: (model: string) => Promise<void>;
 }
 
 let orchestratorInstance: Orchestrator | null = null;
@@ -58,6 +63,8 @@ export const useOrchestratorStore = create<OrchestratorStoreState>((set, get) =>
   activeGroupId: DEFAULT_GROUP_ID,
   ready: false,
   webllmProgress: null,
+  providerId: DEFAULT_PROVIDER as ProviderId,
+  model: DEFAULT_MODEL,
 
   sendMessage: (text) => {
     const orch = getOrchestrator();
@@ -75,6 +82,18 @@ export const useOrchestratorStore = create<OrchestratorStoreState>((set, get) =>
   },
 
   clearError: () => set({ error: null }),
+
+  setProviderId: async (id) => {
+    const orch = getOrchestrator();
+    await orch.setProviderId(id);
+    set({ providerId: id });
+  },
+
+  setModel: async (model) => {
+    const orch = getOrchestrator();
+    await orch.setModel(model);
+    set({ model });
+  },
 
   loadHistory: async () => {
     const msgs = await getRecentMessages(get().activeGroupId, 200);
@@ -156,6 +175,12 @@ export async function initOrchestratorStore(orch: Orchestrator): Promise<void> {
 
   orch.events.on('ready', () => {
     store.setState({ ready: true });
+  });
+
+  // Sync provider/model from orchestrator
+  store.setState({
+    providerId: orch.getProviderId(),
+    model: orch.getModel(),
   });
 
   // Load initial history

--- a/tests/components/chat/ChatPage.test.tsx
+++ b/tests/components/chat/ChatPage.test.tsx
@@ -4,6 +4,8 @@ import { ChatPage } from '../../../src/components/chat/ChatPage';
 const mockSendMessage = vi.fn();
 const mockClearError = vi.fn();
 const mockLoadHistory = vi.fn();
+const mockSetProviderId = vi.fn();
+const mockSetModel = vi.fn();
 
 // Default state — no messages, idle
 const defaultState = {
@@ -21,6 +23,10 @@ const defaultState = {
   clearError: mockClearError,
   loadHistory: mockLoadHistory,
   ready: true,
+  providerId: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  setProviderId: mockSetProviderId,
+  setModel: mockSetModel,
 };
 
 let currentState: any = { ...defaultState };
@@ -164,5 +170,16 @@ describe('ChatPage', () => {
     currentState = { ...defaultState, webllmProgress: null };
     render(<ChatPage />);
     expect(screen.queryByText(/Downloading model/)).toBeNull();
+  });
+
+  it('shows model selector in the chat page', () => {
+    render(<ChatPage />);
+    expect(screen.getByLabelText('Select AI model')).toBeInTheDocument();
+  });
+
+  it('model selector shows the current model value', () => {
+    render(<ChatPage />);
+    const select = screen.getByLabelText('Select AI model') as HTMLSelectElement;
+    expect(select.value).toBe('anthropic:claude-sonnet-4-6');
   });
 });

--- a/tests/components/chat/ModelSelector.test.tsx
+++ b/tests/components/chat/ModelSelector.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModelSelector } from '../../../src/components/chat/ModelSelector';
+
+const mockSetProviderId = vi.fn();
+const mockSetModel = vi.fn();
+
+let currentState: any = {
+  providerId: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  state: 'idle',
+  setProviderId: mockSetProviderId,
+  setModel: mockSetModel,
+};
+
+vi.mock('../../../src/stores/orchestrator-store', () => {
+  const store: any = vi.fn((selector: any) => {
+    return selector ? selector(currentState) : currentState;
+  });
+  store.getState = () => currentState;
+  return { useOrchestratorStore: store };
+});
+
+describe('ModelSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentState = {
+      providerId: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      state: 'idle',
+      setProviderId: mockSetProviderId,
+      setModel: mockSetModel,
+    };
+  });
+
+  it('renders with the current model label', () => {
+    render(<ModelSelector />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    // Should have the current model selected
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('anthropic:claude-sonnet-4-6');
+  });
+
+  it('shows all models grouped by provider', () => {
+    render(<ModelSelector />);
+    const options = screen.getAllByRole('option');
+    // All models across all providers should be listed
+    expect(options.length).toBeGreaterThanOrEqual(11); // 3 + 3 + 4 + 1
+  });
+
+  it('shows provider group labels', () => {
+    const { container } = render(<ModelSelector />);
+    const optgroups = container.querySelectorAll('optgroup');
+    expect(optgroups.length).toBe(4);
+    expect(optgroups[0].getAttribute('label')).toBe('Anthropic Claude');
+    expect(optgroups[1].getAttribute('label')).toBe('Google Gemini');
+  });
+
+  it('calls setProviderId and setModel when a different model is selected', async () => {
+    render(<ModelSelector />);
+    const select = screen.getByRole('combobox');
+    await userEvent.selectOptions(select, 'gemini:gemini-2.0-flash');
+    expect(mockSetProviderId).toHaveBeenCalledWith('gemini');
+    expect(mockSetModel).toHaveBeenCalledWith('gemini-2.0-flash');
+  });
+
+  it('calls setModel without setProviderId when selecting a model from the same provider', async () => {
+    render(<ModelSelector />);
+    const select = screen.getByRole('combobox');
+    await userEvent.selectOptions(select, 'anthropic:claude-opus-4-6');
+    expect(mockSetProviderId).not.toHaveBeenCalled();
+    expect(mockSetModel).toHaveBeenCalledWith('claude-opus-4-6');
+  });
+
+  it('is disabled when orchestrator is not idle', () => {
+    currentState = { ...currentState, state: 'thinking' };
+    render(<ModelSelector />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('is enabled when orchestrator is idle', () => {
+    render(<ModelSelector />);
+    expect(screen.getByRole('combobox')).not.toBeDisabled();
+  });
+});

--- a/tests/providers/models.test.ts
+++ b/tests/providers/models.test.ts
@@ -1,0 +1,59 @@
+import { PROVIDERS, getModelLabel, getProviderForModel } from '../../src/providers/models';
+
+describe('providers/models', () => {
+  describe('PROVIDERS', () => {
+    it('has at least 4 providers', () => {
+      expect(PROVIDERS.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('each provider has an id, label, and models array', () => {
+      for (const p of PROVIDERS) {
+        expect(p.id).toBeTruthy();
+        expect(p.label).toBeTruthy();
+        expect(Array.isArray(p.models)).toBe(true);
+        expect(p.models.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('each model has a value and label', () => {
+      for (const p of PROVIDERS) {
+        for (const m of p.models) {
+          expect(m.value).toBeTruthy();
+          expect(m.label).toBeTruthy();
+        }
+      }
+    });
+  });
+
+  describe('getModelLabel', () => {
+    it('returns the display label for a known model', () => {
+      expect(getModelLabel('claude-sonnet-4-6')).toBe('Claude Sonnet 4.6');
+    });
+
+    it('returns the model value itself for an unknown model', () => {
+      expect(getModelLabel('unknown-model')).toBe('unknown-model');
+    });
+
+    it('finds models across different providers', () => {
+      expect(getModelLabel('gemini-2.0-flash')).toBe('Gemini 2.0 Flash');
+      expect(getModelLabel('qwen3-4b')).toBe('Qwen3 4B (2.5 GB)');
+    });
+  });
+
+  describe('getProviderForModel', () => {
+    it('returns the provider for a known model', () => {
+      const provider = getProviderForModel('claude-sonnet-4-6');
+      expect(provider?.id).toBe('anthropic');
+    });
+
+    it('returns undefined for an unknown model', () => {
+      expect(getProviderForModel('unknown-model')).toBeUndefined();
+    });
+
+    it('finds providers for models across different providers', () => {
+      expect(getProviderForModel('gemini-2.0-flash')?.id).toBe('gemini');
+      expect(getProviderForModel('qwen3-4b')?.id).toBe('webllm');
+      expect(getProviderForModel('gemini-nano')?.id).toBe('chrome-ai');
+    });
+  });
+});

--- a/tests/stores/orchestrator-store.test.ts
+++ b/tests/stores/orchestrator-store.test.ts
@@ -19,6 +19,8 @@ describe('useOrchestratorStore', () => {
       activeGroupId: 'br:main',
       ready: false,
       webllmProgress: null,
+      providerId: 'anthropic' as const,
+      model: 'claude-sonnet-4-6',
     });
   });
 
@@ -53,6 +55,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -82,6 +86,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -112,6 +118,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -134,6 +142,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -153,6 +163,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -185,6 +197,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -204,6 +218,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -226,6 +242,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -257,6 +275,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -284,6 +304,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -304,6 +326,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -324,6 +348,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -346,6 +372,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -367,6 +395,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -389,6 +419,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -408,6 +440,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn().mockResolvedValue(undefined),
         compactContext: vi.fn(),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);
@@ -427,6 +461,8 @@ describe('useOrchestratorStore', () => {
         submitMessage: vi.fn(),
         newSession: vi.fn(),
         compactContext: vi.fn().mockResolvedValue(undefined),
+        getProviderId: vi.fn().mockReturnValue('anthropic'),
+        getModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
       } as any;
 
       await initOrchestratorStore(mockOrch);


### PR DESCRIPTION
Users can now see and change the AI model directly in the chat interface without navigating to Settings. The selector shows all available models grouped by provider and persists the selection to the orchestrator.

Closes #69

https://claude.ai/code/session_016RhLiVTjiqAUmXsag3FEq9