### PR TITLE
Implement per-provider model persistence and WebLLM engine cleanup

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -189,13 +189,9 @@ export function SettingsPage() {
   async function handleProviderChange(id: ProviderId) {
     setProviderId(id);
     await orch.setProviderId(id);
-    // Set default model for new provider
-    const prov = PROVIDERS.find((p) => p.id === id);
-    if (prov && prov.models.length > 0) {
-      const newModel = prov.models[0].value;
-      setModel(newModel);
-      await orch.setModel(newModel);
-    }
+    // Orchestrator restores the last-used model for this provider.
+    // Sync UI state with whatever the orchestrator chose.
+    setModel(orch.getModel());
   }
 
   async function handleSaveAnthropicKey() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,3 +93,37 @@ export const CONFIG_KEYS = {
   ASSISTANT_NAME: 'assistant_name',
   USER_PROFILE: 'user_profile',
 } as const;
+
+/**
+ * Build a per-provider config key for storing the last-used model.
+ * E.g., providerModelKey('webllm') → 'model:webllm'
+ */
+export function providerModelKey(providerId: string): string {
+  return `model:${providerId}`;
+}
+
+/** Known models for each provider — used for validation on load. */
+export const PROVIDER_MODELS: Record<string, string[]> = {
+  anthropic: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  gemini: ['gemini-2.5-pro-preview-06-05', 'gemini-2.0-flash', 'gemini-2.0-flash-lite'],
+  webllm: ['qwen3-0.6b', 'qwen3-1.7b', 'qwen3-4b', 'qwen3-30b'],
+  'chrome-ai': ['gemini-nano'],
+};
+
+/** Default model for each provider (first in the list). */
+export const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  gemini: 'gemini-2.5-pro-preview-06-05',
+  webllm: 'qwen3-0.6b',
+  'chrome-ai': 'gemini-nano',
+};
+
+/**
+ * Check if a model ID is valid for a given provider.
+ * Returns false if the provider is unknown or the model doesn't belong to it.
+ */
+export function isValidModelForProvider(model: string, providerId: string): boolean {
+  const models = PROVIDER_MODELS[providerId];
+  if (!models) return false;
+  return models.includes(model);
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -28,7 +28,10 @@ import {
   DEFAULT_MAX_TOKENS,
   DEFAULT_MODEL,
   DEFAULT_PROVIDER,
+  DEFAULT_PROVIDER_MODELS,
   buildTriggerPattern,
+  isValidModelForProvider,
+  providerModelKey,
 } from './config.js';
 import {
   openDatabase,
@@ -161,6 +164,15 @@ export class Orchestrator {
     );
     this.localPreference = ((await getConfig(CONFIG_KEYS.LOCAL_PREFERENCE)) || 'offline-only') as LocalPreference;
 
+    // Validate that the stored model belongs to the stored provider.
+    // This prevents mismatches (e.g. 'gemini-nano' with provider 'webllm')
+    // that can occur when switching providers doesn't correctly update the model.
+    if (!isValidModelForProvider(this.model, this.providerId)) {
+      const fallback = DEFAULT_PROVIDER_MODELS[this.providerId] || DEFAULT_MODEL;
+      this.model = fallback;
+      await setConfig(CONFIG_KEYS.MODEL, fallback);
+    }
+
     // Set up router
     this.router = new Router(this.browserChat, this.telegram);
 
@@ -249,10 +261,25 @@ export class Orchestrator {
 
   /**
    * Set the active provider.
+   * Also restores the last-used model for this provider (if any).
    */
   async setProviderId(id: ProviderId): Promise<void> {
     this.providerId = id;
     await setConfig(CONFIG_KEYS.PROVIDER, id);
+
+    // Restore last-used model for this provider
+    const savedModel = await getConfig(providerModelKey(id));
+    if (savedModel && isValidModelForProvider(savedModel, id)) {
+      this.model = savedModel;
+      await setConfig(CONFIG_KEYS.MODEL, savedModel);
+    } else {
+      // Fall back to the provider's default model
+      const defaultModel = DEFAULT_PROVIDER_MODELS[id];
+      if (defaultModel) {
+        this.model = defaultModel;
+        await setConfig(CONFIG_KEYS.MODEL, defaultModel);
+      }
+    }
   }
 
   /**
@@ -264,10 +291,13 @@ export class Orchestrator {
 
   /**
    * Update the model.
+   * Also persists it under the current provider so it's restored on provider switch.
    */
   async setModel(model: string): Promise<void> {
     this.model = model;
     await setConfig(CONFIG_KEYS.MODEL, model);
+    // Persist per-provider so we can restore when switching back
+    await setConfig(providerModelKey(this.providerId), model);
   }
 
   /**

--- a/src/providers/webllm.ts
+++ b/src/providers/webllm.ts
@@ -133,6 +133,17 @@ export class WebLLMProvider implements LLMProvider {
 
     this.loading = true;
     try {
+      // Dispose old engine before loading a new model to free WebGPU resources
+      if (this.engine) {
+        try {
+          await this.engine.unload();
+        } catch {
+          // Best-effort cleanup — old engine may already be invalidated
+        }
+        this.engine = null;
+        this.currentModelId = null;
+      }
+
       // Dynamic import to avoid bundling when not needed
       const webllm = await import('@mlc-ai/web-llm');
 

--- a/tests/components/settings/SettingsPage.test.tsx
+++ b/tests/components/settings/SettingsPage.test.tsx
@@ -14,6 +14,15 @@ let mockProviderId = 'anthropic';
 let mockModel = 'claude-sonnet-4-6';
 let mockWebllmProgress: any = null;
 
+// Simulate per-provider model storage (mirrors orchestrator behavior)
+const savedProviderModels: Record<string, string> = {};
+const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  gemini: 'gemini-2.5-pro-preview-06-05',
+  webllm: 'qwen3-0.6b',
+  'chrome-ai': 'gemini-nano',
+};
+
 vi.mock('../../../src/stores/orchestrator-store', () => ({
   useOrchestratorStore: vi.fn((selector) => {
     const state = {
@@ -32,10 +41,14 @@ vi.mock('../../../src/stores/orchestrator-store', () => ({
     setApiKey: mockSetApiKey,
     setProviderId: (...args: any[]) => {
       mockProviderId = args[0];
+      // Simulate orchestrator restoring per-provider model
+      mockModel = savedProviderModels[args[0]] || DEFAULT_PROVIDER_MODELS[args[0]] || mockModel;
       return mockSetProviderId(...args);
     },
     setModel: (...args: any[]) => {
       mockModel = args[0];
+      // Simulate per-provider persistence
+      savedProviderModels[mockProviderId] = args[0];
       return mockSetModel(...args);
     },
     setLocalPreference: mockSetLocalPreference,
@@ -97,6 +110,10 @@ describe('SettingsPage', () => {
     mockModel = 'claude-sonnet-4-6';
     mockWebllmProgress = null;
     mockGetModelCacheEstimate.mockResolvedValue(0);
+    // Clear per-provider model storage
+    for (const key of Object.keys(savedProviderModels)) {
+      delete savedProviderModels[key];
+    }
   });
 
   afterEach(() => {
@@ -165,7 +182,7 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Chrome AI (Gemini Nano) (Local)')).toBeInTheDocument();
   });
 
-  it('changes provider and sets default model', async () => {
+  it('changes provider and syncs model from orchestrator', async () => {
     render(<SettingsPage />);
     const providerSelect = screen.getByDisplayValue('Anthropic Claude');
 
@@ -174,7 +191,40 @@ describe('SettingsPage', () => {
     });
 
     expect(mockSetProviderId).toHaveBeenCalledWith('gemini');
-    expect(mockSetModel).toHaveBeenCalledWith('gemini-2.5-pro-preview-06-05');
+    // Model is now restored by the orchestrator (via setProviderId), not set directly
+    // The UI syncs via orch.getModel() instead of calling setModel
+    expect(mockModel).toBe('gemini-2.5-pro-preview-06-05');
+  });
+
+  it('restores per-provider model when switching back to a provider', async () => {
+    render(<SettingsPage />);
+
+    // Select webllm provider
+    const providerSelect = screen.getByDisplayValue('Anthropic Claude');
+    await act(async () => {
+      fireEvent.change(providerSelect, { target: { value: 'webllm' } });
+    });
+
+    // Change model within webllm to qwen3-4b
+    const modelSelect = screen.getByDisplayValue('Qwen3 0.6B (400 MB)');
+    await act(async () => {
+      fireEvent.change(modelSelect, { target: { value: 'qwen3-4b' } });
+    });
+    expect(mockSetModel).toHaveBeenCalledWith('qwen3-4b');
+
+    // Switch to chrome-ai
+    const providerSelect2 = screen.getByDisplayValue('WebLLM (Local) (Local)');
+    await act(async () => {
+      fireEvent.change(providerSelect2, { target: { value: 'chrome-ai' } });
+    });
+    expect(mockModel).toBe('gemini-nano');
+
+    // Switch back to webllm — should restore qwen3-4b
+    const providerSelect3 = screen.getByDisplayValue('Chrome AI (Gemini Nano) (Local)');
+    await act(async () => {
+      fireEvent.change(providerSelect3, { target: { value: 'webllm' } });
+    });
+    expect(mockModel).toBe('qwen3-4b');
   });
 
   // ---- Model selection ----

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -24,6 +24,10 @@ import {
   APP_URL,
   WEBSITE_URL,
   APP_VERSION,
+  providerModelKey,
+  PROVIDER_MODELS,
+  DEFAULT_PROVIDER_MODELS,
+  isValidModelForProvider,
 } from '../src/config';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -117,5 +121,53 @@ describe('buildTriggerPattern', () => {
 
   it('TRIGGER_PATTERN matches default name', () => {
     expect(TRIGGER_PATTERN.test('@Andy hello')).toBe(true);
+  });
+});
+
+describe('providerModelKey', () => {
+  it('builds per-provider config key', () => {
+    expect(providerModelKey('webllm')).toBe('model:webllm');
+    expect(providerModelKey('anthropic')).toBe('model:anthropic');
+    expect(providerModelKey('chrome-ai')).toBe('model:chrome-ai');
+  });
+});
+
+describe('PROVIDER_MODELS', () => {
+  it('has models for all known providers', () => {
+    expect(PROVIDER_MODELS['anthropic'].length).toBeGreaterThan(0);
+    expect(PROVIDER_MODELS['gemini'].length).toBeGreaterThan(0);
+    expect(PROVIDER_MODELS['webllm'].length).toBeGreaterThan(0);
+    expect(PROVIDER_MODELS['chrome-ai'].length).toBeGreaterThan(0);
+  });
+});
+
+describe('DEFAULT_PROVIDER_MODELS', () => {
+  it('has a default model for each known provider', () => {
+    expect(DEFAULT_PROVIDER_MODELS['anthropic']).toBe('claude-sonnet-4-6');
+    expect(DEFAULT_PROVIDER_MODELS['gemini']).toBe('gemini-2.5-pro-preview-06-05');
+    expect(DEFAULT_PROVIDER_MODELS['webllm']).toBe('qwen3-0.6b');
+    expect(DEFAULT_PROVIDER_MODELS['chrome-ai']).toBe('gemini-nano');
+  });
+});
+
+describe('isValidModelForProvider', () => {
+  it('returns true for valid model-provider pairs', () => {
+    expect(isValidModelForProvider('claude-sonnet-4-6', 'anthropic')).toBe(true);
+    expect(isValidModelForProvider('qwen3-4b', 'webllm')).toBe(true);
+    expect(isValidModelForProvider('gemini-nano', 'chrome-ai')).toBe(true);
+  });
+
+  it('returns false for invalid model-provider pairs', () => {
+    expect(isValidModelForProvider('qwen3-4b', 'anthropic')).toBe(false);
+    expect(isValidModelForProvider('gemini-nano', 'webllm')).toBe(false);
+    expect(isValidModelForProvider('claude-sonnet-4-6', 'chrome-ai')).toBe(false);
+  });
+
+  it('returns false for unknown provider', () => {
+    expect(isValidModelForProvider('any-model', 'unknown-provider')).toBe(false);
+  });
+
+  it('returns false for unknown model', () => {
+    expect(isValidModelForProvider('nonexistent-model', 'anthropic')).toBe(false);
   });
 });

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -95,6 +95,35 @@ describe('Orchestrator', () => {
       await orchestrator.setModel('claude-sonnet-4-6');
     });
 
+    it('persists model per provider and restores on provider switch', async () => {
+      // Set a non-default model for webllm
+      await orchestrator.setProviderId('webllm');
+      await orchestrator.setModel('qwen3-4b');
+      expect(orchestrator.getModel()).toBe('qwen3-4b');
+
+      // Switch to chrome-ai — model should change to gemini-nano
+      await orchestrator.setProviderId('chrome-ai');
+      expect(orchestrator.getModel()).toBe('gemini-nano');
+
+      // Switch back to webllm — should restore qwen3-4b (not default qwen3-0.6b)
+      await orchestrator.setProviderId('webllm');
+      expect(orchestrator.getModel()).toBe('qwen3-4b');
+
+      // Clean up
+      await orchestrator.setProviderId('anthropic');
+      await orchestrator.setModel('claude-sonnet-4-6');
+    });
+
+    it('falls back to default model when no saved model for provider', async () => {
+      // Switch to gemini for the first time (no saved model)
+      await orchestrator.setProviderId('gemini');
+      expect(orchestrator.getModel()).toBe('gemini-2.5-pro-preview-06-05');
+
+      // Clean up
+      await orchestrator.setProviderId('anthropic');
+      await orchestrator.setModel('claude-sonnet-4-6');
+    });
+
     it('sets local preference', async () => {
       await orchestrator.setLocalPreference('always');
       expect(orchestrator.getLocalPreference()).toBe('always');

--- a/tests/providers/webllm.test.ts
+++ b/tests/providers/webllm.test.ts
@@ -330,6 +330,81 @@ describe('WebLLMProvider', () => {
       expect(response.content).toBeDefined();
     });
 
+    it('disposes old engine when switching to a different model', async () => {
+      const webllm = await import('@mlc-ai/web-llm');
+      const mockUnload = vi.fn().mockResolvedValue(undefined);
+
+      // First load creates an engine with unload
+      (webllm.CreateMLCEngine as any).mockResolvedValueOnce({
+        chat: {
+          completions: {
+            create: vi.fn().mockResolvedValue({
+              choices: [{ message: { content: 'model A' } }],
+              usage: { prompt_tokens: 5, completion_tokens: 3 },
+            }),
+          },
+        },
+        unload: mockUnload,
+      });
+
+      const freshProvider = new WebLLMProvider();
+
+      // Load first model
+      await freshProvider.chat({
+        model: 'qwen3-0.6b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      // Switch to a different model — should call unload on old engine
+      await freshProvider.chat({
+        model: 'qwen3-4b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(mockUnload).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles unload failure gracefully when switching models', async () => {
+      const webllm = await import('@mlc-ai/web-llm');
+
+      // First engine has a failing unload
+      (webllm.CreateMLCEngine as any).mockResolvedValueOnce({
+        chat: {
+          completions: {
+            create: vi.fn().mockResolvedValue({
+              choices: [{ message: { content: 'model A' } }],
+              usage: { prompt_tokens: 5, completion_tokens: 3 },
+            }),
+          },
+        },
+        unload: vi.fn().mockRejectedValue(new Error('unload failed')),
+      });
+
+      const freshProvider = new WebLLMProvider();
+
+      // Load first model
+      await freshProvider.chat({
+        model: 'qwen3-0.6b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      // Should not throw even though unload fails
+      const response = await freshProvider.chat({
+        model: 'qwen3-4b',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(response.content).toBeDefined();
+    });
+
     it('handles progress report with missing fields (lines 141-142)', async () => {
       const onProgress = vi.fn();
       const progressProvider = new WebLLMProvider(onProgress);


### PR DESCRIPTION
## Summary
This PR implements per-provider model persistence so that when users switch between providers, their last-used model for each provider is automatically restored. It also adds proper resource cleanup in the WebLLM provider by disposing old engines when switching models.

## Key Changes

### Per-Provider Model Persistence
- Added `providerModelKey()` utility function to generate provider-specific config keys (e.g., `model:webllm`)
- Added `PROVIDER_MODELS` and `DEFAULT_PROVIDER_MODELS` constants to define valid models and defaults for each provider
- Added `isValidModelForProvider()` validation function to ensure model-provider consistency
- Modified `Orchestrator.setProviderId()` to restore the last-used model for a provider or fall back to the provider's default
- Modified `Orchestrator.setModel()` to persist the model under the current provider's key for future restoration
- Updated `SettingsPage` to sync UI state with the orchestrator's model selection instead of forcing a default

### WebLLM Engine Resource Management
- Added engine disposal logic in `WebLLMProvider.chat()` to call `unload()` on the old engine before loading a new model
- Wrapped unload in try-catch to gracefully handle cleanup failures without blocking model switching
- Prevents WebGPU resource leaks when switching between different models

### Validation & Consistency
- Added validation in `Orchestrator.initialize()` to detect and fix model-provider mismatches (e.g., when stored model doesn't belong to stored provider)
- Falls back to provider's default model if validation fails

## Testing
- Added comprehensive tests for per-provider model restoration and switching
- Added tests for WebLLM engine disposal on model switch and graceful failure handling
- Added tests for config utilities and validation functions
- Updated existing provider switch test to verify orchestrator-driven model restoration

https://claude.ai/code/session_014V4GSwdQcX2mkyrh3CbFcF