### PR TITLE
Fix skill list to filter by downloads and non-suspicious skills

### DIFF
--- a/src/skill-hub.ts
+++ b/src/skill-hub.ts
@@ -142,6 +142,8 @@ export async function listSkills(options?: {
   cursor?: string;
 }): Promise<HubSkillsResponse> {
   const params = new URLSearchParams();
+  params.set('sort', 'downloads');
+  params.set('nonSuspicious', 'true');
   if (options?.limit !== undefined) params.set('limit', String(options.limit));
   if (options?.cursor) params.set('cursor', options.cursor);
 

--- a/tests/skill-hub.test.ts
+++ b/tests/skill-hub.test.ts
@@ -137,6 +137,17 @@ describe('skill-hub', () => {
       expect(result.nextCursor).toBe('abc123');
     });
 
+    it('always includes sort=downloads and nonSuspicious=true params', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockFetchResponse({ items: [], nextCursor: null }),
+      );
+
+      await listSkills();
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('sort=downloads');
+      expect(url).toContain('nonSuspicious=true');
+    });
+
     it('passes limit parameter', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         mockFetchResponse({ items: [], nextCursor: null }),


### PR DESCRIPTION
Add sort=downloads and nonSuspicious=true query parameters to the
listSkills API call so the skill hub sources from the correct ClawHub
endpoint as specified in issue #82.

Closes #82

https://claude.ai/code/session_01Ybs4jNe2cuHMD7hF4ygJEG