### PR TITLE
Replace corsproxy.io with corsproxy.org to fix CORS 403 error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export const FETCH_MAX_RESPONSE = 20_000;
  */
 export const CORS_PROXIES: readonly string[] = [
   'https://api.allorigins.win/raw?url=',
-  'https://corsproxy.io/?url=',
+  'https://corsproxy.org/?url=',
 ];
 
 /** Timeout (ms) for each individual fetch attempt (direct + each proxy) */


### PR DESCRIPTION
corsproxy.io now restricts free usage to localhost/dev environments, causing 403 errors in production. Switch to corsproxy.org as the fallback CORS proxy.

Fixes #91

https://claude.ai/code/session_01BsfcMPH5gJapZBuqJ7fd92