### PR TITLE
Fix Gemini tool_result functionResponse name mapping

### DIFF
--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -76,6 +76,19 @@ export class GeminiProvider implements LLMProvider {
 function convertMessages(messages: ConversationMessage[]): GeminiContent[] {
   const contents: GeminiContent[] = [];
 
+  // Build a lookup from tool_use_id → tool name across all messages,
+  // so tool_result blocks can reference the correct function name.
+  const toolNameById = new Map<string, string>();
+  for (const msg of messages) {
+    if (typeof msg.content !== 'string') {
+      for (const block of msg.content as ContentBlock[]) {
+        if (block.type === 'tool_use') {
+          toolNameById.set(block.id, block.name);
+        }
+      }
+    }
+  }
+
   for (const msg of messages) {
     const role = msg.role === 'assistant' ? 'model' : 'user';
 
@@ -97,7 +110,7 @@ function convertMessages(messages: ConversationMessage[]): GeminiContent[] {
         } else if (block.type === 'tool_result') {
           parts.push({
             functionResponse: {
-              name: '', // Gemini uses name but we track by ID — we'll fill this in
+              name: toolNameById.get(block.tool_use_id) || 'unknown',
               response: { content: block.content },
             },
           });

--- a/tests/providers/gemini.test.ts
+++ b/tests/providers/gemini.test.ts
@@ -182,6 +182,79 @@ describe('GeminiProvider', () => {
       expect(body.contents).toHaveLength(3);
     });
 
+    it('populates functionResponse.name from preceding tool_use block', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse(createGeminiResponse('ok'))
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await provider.chat({
+        model: 'gemini-2.5-flash',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [
+          { role: 'user', content: 'hello' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Let me check' },
+              { type: 'tool_use', id: 't1', name: 'fetch_url', input: { url: 'https://example.com' } },
+              { type: 'tool_use', id: 't2', name: 'bash', input: { command: 'ls' } },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 't1', content: 'page content' },
+              { type: 'tool_result', tool_use_id: 't2', content: 'file.txt' },
+            ],
+          },
+        ],
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+
+      // The tool_result message (index 2) should have functionResponse parts with correct names
+      const toolResultParts = body.contents[2].parts;
+      expect(toolResultParts[0].functionResponse.name).toBe('fetch_url');
+      expect(toolResultParts[1].functionResponse.name).toBe('bash');
+    });
+
+    it('uses "unknown" as fallback when tool_use_id has no matching tool_use', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse(createGeminiResponse('ok'))
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await provider.chat({
+        model: 'gemini-2.5-flash',
+        maxTokens: 1024,
+        system: 'test',
+        messages: [
+          { role: 'user', content: 'hello' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'response' },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'orphan-id', content: 'result' },
+            ],
+          },
+        ],
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+
+      const toolResultParts = body.contents[2].parts;
+      expect(toolResultParts[0].functionResponse.name).toBe('unknown');
+    });
+
     it('skips empty parts array from content blocks', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         mockFetchResponse(createGeminiResponse('ok'))


### PR DESCRIPTION
## Summary
Fixed the Gemini provider to correctly populate the `functionResponse.name` field when converting tool_result blocks. Previously, the name was left empty; now it's properly mapped from the preceding tool_use block.

## Key Changes
- Added a lookup map (`toolNameById`) that tracks all tool_use blocks across messages before processing, mapping tool IDs to their function names
- Updated tool_result conversion to use this map to populate `functionResponse.name` with the correct function name
- Implemented fallback to `'unknown'` when a tool_result references a tool_use_id that doesn't exist in the conversation history

## Implementation Details
- The tool name lookup is built in a single pass through all messages before the main conversion loop, ensuring all tool_use blocks are indexed regardless of message order
- This approach handles multiple tool_use blocks in a single assistant message correctly
- The fallback behavior gracefully handles edge cases where tool_result references are orphaned or malformed

https://claude.ai/code/session_011FH4aFka8CxLgREjm7MrZY